### PR TITLE
Event panel visibility

### DIFF
--- a/extension/src/app.js
+++ b/extension/src/app.js
@@ -189,7 +189,7 @@ function adMonitor () {
             '.video-ads.ytp-ad-module', // middle banner
             '.ytp-ad-player-overlay-instream-info', // ad below
             '.ytp-title-channel', // title top
-            '.ytp-title-text', // title 
+            '.ytp-title-text', // title
             '.ytp-chrome-top' // other title top
         ];
 
@@ -198,9 +198,9 @@ function adMonitor () {
                 .querySelectorAll(s)
                 .forEach(function (element) {
                     if (_.size(element.textContent)) {
-                        console.log(s, "===}>", element.textContent)
+                        console.log(s, '===}>', element.textContent);
                         if (testElement(element.outerHTML, s))
-                            phase('adv.seen'); 
+                            phase('adv.seen');
                     }
                 });
         });

--- a/extension/src/panel.js
+++ b/extension/src/panel.js
@@ -28,7 +28,7 @@ export function createElement (tag, cssProp = {}, parent = document.body, id = n
 }
 
 const containerCSS = {
-  position: 'fixed',
+  position: 'absolute',
   top: '0rem',
   left: '0rem',
   display: 'flex',
@@ -130,16 +130,26 @@ export function createPanel (events, helpBody = '') {
     const isFullScreen = getIsFullScreen();
     container.style.visibility = isFullScreen ? 'hidden' : 'visible';
 
-    const videoElements = [...document.querySelectorAll('video')];
-    // NOTE: is there a YouTube state where there more then one video in the page?
-    if (videoElements.length === 1) {
-      const video = videoElements[0];
-
-      const videoWidth = Number(video.style.width.slice(0, -2));
-      const isTheatreMode = videoWidth === window.innerWidth;
-      container.style.top = isTheatreMode ? Number(video.style.height.slice(0, -2) + 50) : 0;
-    }
+    checkTheatreMode();
   }, 2000);
 
+  window.addEventListener('resize', checkTheatreMode);
+
   return Object.fromEntries(nameBlink);
+}
+
+function checkTheatreMode () {
+  const container = document.getElementById('panel')
+  const videoElements = [...document.querySelectorAll('video')];
+
+  // NOTE: is there a YouTube state where there more then one video in the page?
+  if (videoElements.length === 1) {
+    const video = videoElements[0];
+
+    const videoWidth = Number(video.style.width.slice(0, -2));
+    const isTheatreMode = videoWidth === window.innerWidth;
+    container.style.paddingTop = isTheatreMode
+      ? (Number(video.style.height.slice(0, -2)) + 73) + 'px'
+      : 0;
+  }
 }

--- a/extension/src/panel.js
+++ b/extension/src/panel.js
@@ -56,11 +56,30 @@ const helpCSS = {
   visibility: 'hidden'
 };
 
+let visibilityTimerId = null;
+
+/**
+ * Check if the page is in full screen
+ */
+function getIsFullScreen () {
+  return window.innerHeight === screen.height;
+}
+
 /**
  * Create the panel
  * @param {object} Object like: {[EVENT_NAME]: {color: string}}
  */
 export function createPanel (events, helpBody = '') {
+  const alreadyInitializedPanel = [...document.querySelectorAll('#panel')]
+  if (alreadyInitializedPanel.length > 0) {
+    console.warn('YTTREX > panel ===}> panel is already initialized, maybe extension reloaded twice?');
+    alreadyInitializedPanel.forEach(p => document.body.removeChild(p));
+  }
+
+  if (visibilityTimerId) {
+    clearInterval(visibilityTimerId);
+  }
+
   const gray = '#bbb';
 
   const container = createElement('div', containerCSS, document.body, 'panel');
@@ -106,6 +125,21 @@ export function createPanel (events, helpBody = '') {
     };
     return [eventName, blink];
   });
+
+  visibilityTimerId = setInterval(() => {
+    const isFullScreen = getIsFullScreen();
+    container.style.visibility = isFullScreen ? 'hidden' : 'visible';
+
+    const videoElements = [...document.querySelectorAll('video')];
+    // NOTE: is there a YouTube state where there more then one video in the page?
+    if (videoElements.length === 1) {
+      const video = videoElements[0];
+
+      const videoWidth = Number(video.style.width.slice(0, -2));
+      const isTheatreMode = videoWidth === window.innerWidth;
+      container.style.top = isTheatreMode ? Number(video.style.height.slice(0, -2) + 50) : 0;
+    }
+  }, 2000);
 
   return Object.fromEntries(nameBlink);
 }


### PR DESCRIPTION
This PR add some code to:

- hide the panel if the page is in full screen
- push the panel down if the page is in theatre mode (see the screenshot below)
- check if the extension is already loaded and clean up the DOM before add elements to avoid duplication.

The last point is to patch a bug that was caused by manually reloading the extension (I think, but few times I had all the extension event panel duplicated).

See this screenshot for what Theatre Mode is about:

![image](https://user-images.githubusercontent.com/609314/80830728-c6f7f080-8be9-11ea-847e-cc4a808cc4a2.png)
