### PR TITLE
[WIP] fix: on the way to make the recommendations work

### DIFF
--- a/backend/bin/server.js
+++ b/backend/bin/server.js
@@ -141,7 +141,7 @@ app.post('/api/v3/creator/ogp', cors(), async (req, res) => await iowrapper('ogp
 app.get('/api/v3/creator/videos', async (req, res) => await iowrapper('getVideoByCreator', req, res))
 app.post('/api/v3/creator/videos/repull', async (req, res) => await iowrapper('repullByCreator', req, res))
 
-app.get('/api/v3/creator/recommendations/:IGNORED_CHANNELID', async (req, res) => await iowrapper('youChooseByProfile', req, res))
+app.get('/api/v3/creator/recommendations', async (req, res) => await iowrapper('youChooseByProfile', req, res))
 app.get('/api/v3/creator/:channelId/related/:amount?', async (req, res) => await iowrapper('getCreatorRelated', req, res))
 app.get('/api/v3/creator/:channelId/stats', async (req, res) => await iowrapper('getCreatorStats', req, res))
 
@@ -190,7 +190,7 @@ app.get('/api/v2/experiment/:expname/dot', cors(), async (req, res) => await iow
 app.get('/api/v2/experiment/:expname/json', cors(), async (req, res) => await iowrapper('experimentJSON', req, res))
 app.get('/api/v2/guardoni/list', async (req, res) => await iowrapper('getAllExperiments', req, res))
 
-// dynamically configured and retrived guardoni settings 
+// dynamically configured and retrived guardoni settings
 app.post('/api/v2/guardoni/:experiment/:botname', async (req, res) => await iowrapper('guardoniConfigure', req, res))
 app.get('/api/v2/guardoni/:experiment/:botname', async (req, res) => await iowrapper('guardoniGenerate', req, res))
 

--- a/backend/lib/ycai.js
+++ b/backend/lib/ycai.js
@@ -79,7 +79,7 @@ async function fetchRecommendationsByProfile(token) {
 
 function attributeFromDomain(domain) {
   // for youtube, facebook, twitter, wikipedia, and
-  // any other website that we want to recognize with 
+  // any other website that we want to recognize with
   // their favicon in the interface, we can match it
   const map = {
     'youtube': ['youtube.com', 'youtu.be'],
@@ -88,7 +88,7 @@ function attributeFromDomain(domain) {
   }
   return _.filter(_.keys(map), function(k) {
     const dlist = map[k];
-    return _.same(dlist, function(dtest) {
+    return _.some(dlist, function(dtest) {
       return _.endsWith(domain, dtest);
     });
   });
@@ -301,10 +301,10 @@ async function registerVideos(videol, channelId) {
 }
 
 async function getCreatorByToken(token) {
-  // this function might be executed to query the 
-  // state of a content creator. it might be 
-  // fully authenticated, or not. the filter 
-  // works on creators and tokens, considering the 
+  // this function might be executed to query the
+  // state of a content creator. it might be
+  // fully authenticated, or not. the filter
+  // works on creators and tokens, considering the
   // token are going to expire automatically.
   const mongoc = await mongo3.clientConnect({ concurrency: 1 });
   const creator = await mongo3

--- a/backend/lib/ycai.js
+++ b/backend/lib/ycai.js
@@ -65,11 +65,12 @@ async function fetchRecommendationsByProfile(token) {
   const results = await mongo3.readLimit(
     mongoc,
     nconf.get("schema").recommendations,
-    { creator: creator.channelId },
+    { channelId: creator.channelId },
     { when: -1 },
     INTERFACE_MAX,
     0
   );
+  console.log('fetchRecommendationsByProfile', creator);
   if (INTERFACE_MAX == results.length) {
     debug("More recommendations than what is possible! (we should support pagination)");
   }


### PR DESCRIPTION
- fixed a typo in `_.some` that made adding a recommendation fail
- about removing [IGNORED_CHANNELID](https://github.com/tracking-exposed/yttrex/pull/111/commits/52025838ab6555b6addb94e2b73771baedd48e89), what is the reason to keep it? the client doesn't seem to use it and it causes 404's, if this param is needed, then maybe we can make it optional
- changed the query in "fetchRecommendationsByProfile" to what seemed logical according to the database schema, because the method was always returning an empty array. My fix might be wrong, but something is not coherent in the code.

sorry about the whitespace trimming, that's vscode doing it automatically :)