### PR TITLE
fix: update Video model, removing "image" & "url"

### DIFF
--- a/backend/models/Video.ts
+++ b/backend/models/Video.ts
@@ -1,11 +1,12 @@
 import * as t from 'io-ts';
-import { Recommendation } from './Recommendation';
 
 export const Video = t.strict(
   {
-    ...Recommendation.type.props,
-    videoId: t.string,
+    description: t.union([t.string, t.undefined ]),
     recommendations: t.array(t.string),
+    title: t.string,
+    urlId: t.string,
+    videoId: t.string,
   },
   'Video'
 );


### PR DESCRIPTION
Video was inheriting part of its properties from Recommendation,
which made the validation fail since Recommendation has a url
and mandatory image and Video has not.

So I removed the dependency on Recommendation and instead listed
all the fields that are present in database except creatorId,
which you seem to have left out on purpose.