### PR TITLE
[open for discussion] fix: delete recommendation description when null

### DIFF
--- a/backend/lib/ycai.js
+++ b/backend/lib/ycai.js
@@ -46,6 +46,9 @@ async function fetchRecommendations(videoId, kind) {
 
     result = _.map(result, function (e) {
       _.unset(e, "_id");
+      if (e.description === null) {
+        delete e.description;
+      }
       return e;
     });
     result = _.sortBy(result, [


### PR DESCRIPTION
this null should probably not be stored in the first place,
the model expects undefined or string

this is not a full fix, but I thought that, in principle, it
may not be absurd to have some kind of filter on the database
output because we will change our schema all the time and updating
on read is a valid data-migration strategy