### PR TITLE
Added proxy, headless, config_file options as for potrex 

### DIFF
--- a/backend/bin/server.js
+++ b/backend/bin/server.js
@@ -73,6 +73,11 @@ app.options('/api/', cors())
 app.use(bodyParser.json({limit: '6mb'}));
 app.use(bodyParser.urlencoded({limit: '6mb', extended: true}));
 
+/* this API is v0 as it is platform neutral. it might be shared among 
+ * all the trex backends, and should return info on system health, echo OK
+ * if the system is OK, and the git log of the code running */
+app.get('/api/v0/info', async (req, res) => await iowrapper('systemInfo', req, res));
+
 app.get('/api/v1/last', async (req, res) => await iowrapper('getLast', req, res))
 app.get('/api/v1/home', async (req, res) => await iowrapper('getLastHome', req, res))
 app.get('/api/v1/videoId/:query', async (req, res) => await iowrapper('getVideoId', req, res))
@@ -80,9 +85,7 @@ app.get('/api/v1/related/:query', async (req, res) => await iowrapper('getRelate
 app.get('/api/v1/videoCSV/:query/:amount?', async (req, res) => await iowrapper('getVideoCSV', req, res))
 app.get('/api/v1/author/:query/:amount?', async (req, res) => await iowrapper('getByAuthor', req, res))
 
-/* This is import and validate the key */
-app.post('/api/v:version/validate', async (req, res) => await iowrapper('validateKey', req, res))
-app.post('/api/v1/events', async (req, res) => await iowrapper('discontinued', req, res))
+/* This is the API meant to receive data donation */
 app.post('/api/v2/events', async (req, res) => await iowrapper('processEvents2', req, res))
 
 /* new timeline timeseries on top */
@@ -133,7 +136,7 @@ app.get('/api/v3/video/:videoId/recommendations', async (req, res) => await iowr
 app.get('/api/v3/recommendations/:ids', async (req, res) => await iowrapper('recommendationById', req, res))
 
 app.post('/api/v3/creator/updateVideo', async (req, res) => await iowrapper('updateVideoRec', req, res))
-app.post('/api/v3/creator/ogp', cors(), async (req, res) => await iowrapper('ogpProxy', req, res))
+app.post('/api/v3/creator/ogp', async (req, res) => await iowrapper('ogpProxy', req, res))
 app.get('/api/v3/creator/videos', async (req, res) => await iowrapper('getVideoByCreator', req, res))
 app.post('/api/v3/creator/videos/repull', async (req, res) => await iowrapper('repullByCreator', req, res))
 
@@ -182,8 +185,8 @@ app.post('/api/v2/campaigns/:key', async (req, res) => await iowrapper('updateCa
 app.post('/api/v2/experiment/opening', async (req, res) => await iowrapper('experimentOpening', req, res))
 app.post('/api/v2/experiment', async (req, res) => await iowrapper('experimentSubmission', req, res))
 app.get('/api/v2/experiment/:expname/csv', async (req, res) => await iowrapper('experimentCSV', req, res))
-app.get('/api/v2/experiment/:expname/dot', cors(), async (req, res) => await iowrapper('experimentDOT', req, res))
-app.get('/api/v2/experiment/:expname/json', cors(), async (req, res) => await iowrapper('experimentJSON', req, res))
+app.get('/api/v2/experiment/:expname/dot', async (req, res) => await iowrapper('experimentDOT', req, res))
+app.get('/api/v2/experiment/:expname/json', async (req, res) => await iowrapper('experimentJSON', req, res))
 app.get('/api/v2/guardoni/list', async (req, res) => await iowrapper('getAllExperiments', req, res))
 
 // dynamically configured and retrived guardoni settings

--- a/backend/lib/api.js
+++ b/backend/lib/api.js
@@ -1,6 +1,6 @@
 
 const apiList = {
-    discontinued:        require('../routes/public').discontinued,
+    systemInfo:          require('../routes/system').systemInfo,
     processEvents2:      require('../routes/events').processEvents2,
     getMirror:           require('../routes/events').getMirror,
 

--- a/backend/lib/automo.js
+++ b/backend/lib/automo.js
@@ -161,7 +161,20 @@ async function getMetadataFromAuthorChannelId(channelId, options) {
         nconf.get('schema').metadata, { authorSource: channelId },
         { savingTime: -1 }, 100, options.skip);
 
-    const authors = _.reduce(_.flatten(_.map(videos, 'related')), function(memo, related) {
+    const relatedl = _.compact(_.flatten(_.map(videos, 'related')));
+    debug("matching %d videos by authorSource (%j) had %d total related",
+        videos.length, channelId, relatedl.length);
+
+    if(!relatedl) {
+        await mongoc.close();
+        /* structure to say "No data available" */
+        return {
+            content: [], overflow: false, total: 0,
+            pagination: options,
+        };
+    }
+
+    const authors = _.reduce(relatedl, function(memo, related) {
         rs = related.recommendedSource;
         if(!memo[rs]) {
             const obj = {

--- a/backend/lib/ycai.js
+++ b/backend/lib/ycai.js
@@ -83,7 +83,6 @@ async function fetchRecommendations(videoId, kind) {
 }
 
 async function fetchRecommendationsByProfile(token) {
-  // cryptography and authentication not yet implemented
   const INTERFACE_MAX = 100;
   const mongoc = await mongo3.clientConnect({ concurrency: 1 });
   const creator = await mongo3
@@ -96,7 +95,6 @@ async function fetchRecommendationsByProfile(token) {
     INTERFACE_MAX,
     0
   );
-  console.log('fetchRecommendationsByProfile', creator);
   if (INTERFACE_MAX == results.length) {
     debug("More recommendations than what is possible! (we should support pagination)");
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "youtube.tracking.exposed - backend data collector",
   "scripts": {
     "watch": "key=fuffa DEBUG=*,-express:*,-body-parser:*,-follow-redirects node_modules/.bin/ts-node-dev --respawn --transpile-only bin/server.js",
-    "start": "DEBUG=*,-body-parser:*,-express:*,-lib:*,-follow-redirects ts-node bin/server",
+    "start": "gitlog=`git log -30 --stat --oneline --decorate --graph` DEBUG=*,-body-parser:*,-express:*,-lib:*,-follow-redirects ts-node bin/server",
     "parserv": "DEBUG=*,-pubtimeAPI node_modules/.bin/ts-node bin/parserv2.js",
     "parserv:watch": "DEBUG=*,-pubtimeAPI node_modules/.bin/ts-node-dev --respawn --transpile-only bin/parserv2.js",
     "leaveserv": "DEBUG=* node bin/leaveserv.js",

--- a/backend/routes/events.js
+++ b/backend/routes/events.js
@@ -87,11 +87,10 @@ async function processEvents2(req) {
             publicKey: headers.publickey,
             randomUUID: body.randomUUID,
             href: body.href,
-            type: body.type,
         });
         const id = utils.hash({
             metadataId,
-            size: body.size,
+            size: body.element.length,
             i,
         });
         const html = {
@@ -125,6 +124,7 @@ async function processEvents2(req) {
         const metadataId = utils.hash({
             publicKey: headers.publickey,
             randomUUID: e.randomUUID,
+            href: e.href,
             type: 'leaf',
         });
         const id = utils.hash({

--- a/backend/routes/public.js
+++ b/backend/routes/public.js
@@ -253,7 +253,7 @@ async function getCreatorRelated(req) {
     try {
         authorStruct = await automo.getMetadataFromAuthorChannelId(`/channel/${req.params.channelId}`, { amount, skip });
     } catch(e) {
-        debug("getCreatorRelated error: %s", e.message);
+        debug("getCreatorRelated error: %s, %s", e.message, e.stack);
         return {
             json: {
                 error: true,

--- a/backend/routes/statistics.js
+++ b/backend/routes/statistics.js
@@ -5,25 +5,15 @@ const nconf = require('nconf');
 
 const mongo3 = require('../lib/mongo3');
 
-/* -- this cache is shared with yttrex, might be generalized or figured out
- * if something native from mongo exists ? */
-
-/*
- -- suspended
-function formatCached(what, updated)
-function cacheAvailable(what)
-function countStoredDocuments()
-
-function counter(req)
-function parsers(req)
- */
-
 async function statistics(req) {
     // the content in 'stats' is saved by count-o-clock and the selector here required is
     // specifiy in config/stats.json
     const expectedFormat = "/api/v2/statistics/:name/:unit/:amount";
 
-    const allowedNames = ['supporters', 'active', 'related', 'processing', 'metadata', 'usage', 'searches', 'labels', 'deeper'];
+    const allowedNames = ['supporters', 'active', 'related',
+        'processing', 'metadata', 'usage', 'searches',
+        'labels', 'deeper', 'ads', 'ytvids', 'recommendations', 
+        'leaves', 'creators' ];
     const name = req.params.name;
     if(allowedNames.indexOf(name) == -1) {
         debug("Error! this might not appear in visualization: investigate on why an invalid stat-name is called by c3! (%s)", name);
@@ -57,10 +47,12 @@ async function statistics(req) {
     const content = _.map(fullc, function(e) {
         return _.omit(e, ['_id']);
     });
-    debug("Requested [%s] since %d %s ago = %d samples", name, amount, unit, _.size(content));
+    debug("Requested [%s] since %d %s ago = %d measures", name, amount, unit, _.size(content));
     mongoc.close();
     return { json: content,
-        headers: { amount, unit, name }
+        // headers: { amount, unit, name }
+        // there is no reason to add info in the header, 
+        // but that was also a standard in all the *trex backends
     };
 }
 

--- a/backend/routes/system.js
+++ b/backend/routes/system.js
@@ -1,0 +1,25 @@
+const _ = require('lodash');
+const nconf = require('nconf');
+const debug = require('debug')('routes:system');
+
+async function systemInfo(req) {
+  const reqtype = req.params.type || "default";
+
+  debug("Requested %s", reqtype);
+  /* default return the 'gitlog' other might follow */
+
+  const gl = nconf.get('gitlog');
+  if(!gl.length)
+    return {
+      text: "The backend have been started without the standard command so this API can't provide complete information"
+    };
+  else
+    return {
+      // HTML standards you say? HAHAAHAHAH
+      text: "<html><body><pre>" + gl
+    };
+}
+
+module.exports = {
+  systemInfo
+};

--- a/methodology/bin/guardoni.js
+++ b/methodology/bin/guardoni.js
@@ -200,7 +200,10 @@ async function pullDirectives(sourceUrl) {
 async function readExperiment(profinfo) {
 
   let page, experiment = null;
-  const browser = await dispatchBrowser(false, profinfo);
+  // check if headless flag is defined
+  const headless = nconf.get('headless');
+
+  const browser = await dispatchBrowser(headless, profinfo);
 
   try {
     page = (await browser.pages())[0];
@@ -419,7 +422,10 @@ async function main() {
 
   await writeExperimentInfo(experiment, profinfo, evidencetag, directiveType);
 
-  const browser = await dispatchBrowser(false, profinfo);
+  // check if headless flag is defined
+  const headless = nconf.get('headless');
+
+  const browser = await dispatchBrowser(headless, profinfo);
 
   if(browser.newProfile)
     await allowResearcherSomeTimeToSetupTheBrowser(profinfo.profileName);

--- a/methodology/bin/guardoni.js
+++ b/methodology/bin/guardoni.js
@@ -463,6 +463,12 @@ async function dispatchBrowser(headless, profinfo) {
 
   debug("Dispatching a browser in a profile usage count %d", execount);
   let browser = null;
+
+  let proxy = nconf.get('proxy');
+  if(proxy) {
+    proxy = "--proxy-server=" + proxy
+  }
+
   try {
     puppeteer.use(pluginStealth());
     browser = await puppeteer.launch({
@@ -472,7 +478,8 @@ async function dispatchBrowser(headless, profinfo) {
         args: ["--no-sandbox",
           "--disabled-setuid-sandbox",
           "--load-extension=" + dist,
-          "--disable-extensions-except=" + dist
+          "--disable-extensions-except=" + dist,
+          proxy
         ],
     });
 

--- a/methodology/bin/guardoni.js
+++ b/methodology/bin/guardoni.js
@@ -15,7 +15,14 @@ const COMMANDJSONEXAMPLE = "https://youtube.tracking.exposed/json/automation-exa
 const EXTENSION_WITH_OPT_IN_ALREADY_CHECKED='https://github.com/tracking-exposed/yttrex/releases/download/v1.8.99/yttrex-guardoni-1.8.99.zip';
 
 const configPath = path.join("static", "settings.json");
-nconf.argv().env().file(configPath);
+nconf.argv().env();
+nconf.defaults({
+  'headless': false,
+  'proxy': "",
+  'config_file' : configPath
+});
+const configFile = nconf.get('config_file');
+nconf.file(configFile);
 debug.enabled = true;
 
 const server = nconf.get('backend') ?


### PR DESCRIPTION
In these commits you will find the definition of the command line options `--config_file, --headless, --proxy` for guardoni. Please notice that there was a little mess with some commits, check if the history is good for you.