### PR TITLE
chore: fix command to start api with docker-compose

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:12-slim as deps
+
+WORKDIR /app
+
+COPY / ./
+
+RUN npm install
+
+CMD ["npm", "run", "watch"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -24,12 +24,14 @@ services:
       - mongo
 
   api:
-    image: node:12-slim
+    build:
+      context: .
     ports:
       - "9000:9000"
     environment:
       DEBUG: "*,-body-parser*,-express*,-follow-redirects"
       key: my-dev-key
+      mongoHost: mongo
     links:
       - mongo
     volumes:
@@ -40,8 +42,7 @@ services:
       - ./models:/app/models
       - ./parsers:/app/parsers
       - ./routes:/app/routes
-      - ./node_modules:/app/node_modules
       - ./package.json:/app/package.json
       - ./tsconfig.json:/app/tsconfig.json
     working_dir: /app
-    command: npm run watch:ts
+    command: npm run watch


### PR DESCRIPTION
This will let us start the API server by simply running `docker-compose up`. This can be helpful for new devs and ones not really working on API.

Cheers 🍶 