### PR TITLE
fix: docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,8 +43,6 @@ services:
     volumes:
       - ./shared:/app/shared
       - ./backend:/app/backend/
-      - shared-node_modules:/app/shared/node_modules
-      - backend-node_modules:/app/backend/node_modules
     depends_on:
       - mongo
     working_dir: /app/backend
@@ -59,14 +57,7 @@ services:
       - ./shared:/app/shared
       - ./YCAI:/app/YCAI
       - ./YCAI/build:/app/YCAI/build
-      - shared-node_modules:/app/shared/node_modules
-      - ycai-node_modules:/app/YCAI/node_modules
     working_dir: /app/YCAI
     depends_on:
       - api
-    command: npm run watch
-
-volumes:
-  shared-node_modules: {}
-  backend-node_modules: {}
-  ycai-node_modules: {}
+    command: sh -c "chmod -R 777 /app/YCAI/build && npm run watch"


### PR DESCRIPTION
I realized that running `docker-compose up ycai` sets the ownership of the `YCAI/build` folder to root, to prevent this I added a sanity check in the `command` definition for the `web` service.

The other problem was the volumes bound as deps: the volume definition binds the container volume to host, so it won't work for windows users.