### PR TITLE
feat: login flow with token

### DIFF
--- a/YCAI/src/components/common/UnlinkProfileButton.tsx
+++ b/YCAI/src/components/common/UnlinkProfileButton.tsx
@@ -7,7 +7,6 @@ import {
   DialogContent,
   DialogContentText,
   DialogTitle,
-  Typography,
 } from '@material-ui/core';
 import { useTranslation } from 'react-i18next';
 
@@ -55,9 +54,7 @@ const UnlinkProfileButton: React.FC<UnlinkProfileButtonProps> = (props) => {
           </DialogTitle>
           <DialogContent>
             <DialogContentText>
-              <Typography>
-                {t('actions:unlink_channel_confirm_text')}
-              </Typography>
+              {t('actions:unlink_channel_confirm_text')}
             </DialogContentText>
           </DialogContent>
           <DialogActions>

--- a/YCAI/src/components/dashboard/Dashboard.tsx
+++ b/YCAI/src/components/dashboard/Dashboard.tsx
@@ -97,9 +97,17 @@ const DashboardContent: React.FC<DashboardContentProps> = ({
         xs={12}
         style={{
           backgroundColor: theme.palette.background.default,
+          paddingTop: profile ? 0 : theme.spacing(12),
         }}
       >
-        <Typography variant="h3" component="h1" color="primary" style={{ whiteSpace: 'pre-line' }}>
+        <Typography
+          variant="h3"
+          component="h1"
+          color={profile ? 'primary' : 'textPrimary'}
+          style={{
+            whiteSpace: 'pre-line'
+          }}
+        >
           {currentViewLabel}
         </Typography>
         <Typography variant="subtitle1" color="textPrimary">
@@ -128,7 +136,10 @@ export const Dashboard = withQueries(({ queries }): React.ReactElement => {
       return (
         <Grid container className={classes.root} spacing={4}>
           <Grid item sm={12} md={3} lg={2}>
-            <Sidebar currentView={currentView} />
+            <Sidebar
+              currentView={currentView}
+              profile={profile}
+            />
           </Grid>
           <Grid item sm={12} md={9} lg={10}>
             <DashboardContent

--- a/YCAI/src/components/dashboard/LinkAccount.tsx
+++ b/YCAI/src/components/dashboard/LinkAccount.tsx
@@ -1,4 +1,4 @@
-import { AuthResponse } from '@shared/models/Auth';
+import React from 'react';
 import {
   Box,
   Button,
@@ -11,16 +11,18 @@ import {
   Typography,
 } from '@material-ui/core';
 import CopyIcon from '@material-ui/icons/FileCopyOutlined';
+import useCopyClipboard from 'react-use-clipboard';
 import { isLeft } from 'fp-ts/lib/Either';
-import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
+
+import { AuthResponse } from '@shared/models/Auth';
 import {
   registerCreatorChannel,
   updateAuth,
   verifyChannel,
 } from '../../state/dashboard/creator.commands';
 import { makeStyles } from '../../theme';
-import useCopyClipboard from 'react-use-clipboard';
+import TokenLoginModal from './TokenLoginModal';
 
 const youtubeChannelUrlRegex = /\/channel\/([^/]+)(?:$|\/)/;
 
@@ -31,6 +33,11 @@ const useStyles = makeStyles((theme) => ({
   },
   boxGrid: {
     marginTop: theme.spacing(10),
+    marginBottom: theme.spacing(3),
+  },
+  channelInput: {
+    display: 'flex',
+    flexDirection: 'row',
     marginBottom: theme.spacing(3),
   },
   tokenDisplay: {
@@ -78,6 +85,7 @@ export const LinkAccount: React.FC<LinkAccountProps> = ({ auth }) => {
   const [submitChannelFailed, setSubmitChannelFailed] = React.useState(false);
   const [verificationFailed, setVerificationFailed] = React.useState(false);
   const [verifying, setVerifying] = React.useState(false);
+  const [showTokenLoginModal, setShowTokenLoginModal] = React.useState(false);
 
   const channelIDPasted = auth?.tokenString !== undefined;
 
@@ -95,24 +103,18 @@ export const LinkAccount: React.FC<LinkAccountProps> = ({ auth }) => {
     setChannel(e.target.value);
   };
 
-  const onSubmit: React.KeyboardEventHandler<HTMLInputElement> = async (
-    e
-  ): Promise<void> => {
-    // this handle the pressing of "Enter" key
-    if (e.keyCode === 13) {
-      await registerCreatorChannel(e.currentTarget.value, {
-        ccRelatedUsers: { params: { skip: 0, amount: 5 } },
-      })();
-    }
+  const handleChannelSubmit = async (): Promise<void> => {
+    const resp = await registerCreatorChannel(channel, {
+      ccRelatedUsers: { params: { skip: 0, amount: 5 } },
+    })();
+    setSubmitChannelFailed(isLeft(resp));
   };
 
-  const handleChannelSubmit: React.MouseEventHandler<HTMLButtonElement> =
-    async () => {
-      const resp = await registerCreatorChannel(channel, {
-        ccRelatedUsers: { params: { skip: 0, amount: 5 } },
-      })();
-      setSubmitChannelFailed(isLeft(resp));
-    };
+  const onChannelKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (e) => {
+    if (e.key === 'Enter') {
+      void handleChannelSubmit();
+    }
+  };
 
   const handleVerifyChannelClicked = (): void => {
     setVerifying(true);
@@ -158,7 +160,7 @@ export const LinkAccount: React.FC<LinkAccountProps> = ({ auth }) => {
         alignItems="flex-end"
       >
         <Grid item xs={12} sm={6}>
-          <FormControl style={{ display: 'flex', flexDirection: 'row' }}>
+          <FormControl className={classes.channelInput}>
             <InputLabel htmlFor="creator-channel">
               {t('account:channel')}
             </InputLabel>
@@ -167,9 +169,27 @@ export const LinkAccount: React.FC<LinkAccountProps> = ({ auth }) => {
               fullWidth={true}
               value={channel}
               onChange={handleChannelChange}
-              onKeyDown={onSubmit}
+              onKeyDown={onChannelKeyDown}
             />
           </FormControl>
+          <Typography>
+            <Trans i18nKey="link_account:already_have_token">
+              Or
+              <Link
+                className={classes.linkButton}
+                onClick={() => setShowTokenLoginModal(true)}
+              >
+                click here
+              </Link>
+              if you already have an access token.
+            </Trans>
+          </Typography>
+          {showTokenLoginModal && (
+            <TokenLoginModal
+              isOpen={showTokenLoginModal}
+              onClose={() => setShowTokenLoginModal(false)}
+            />
+          )}
         </Grid>
         <Grid item xs={12} className={classes.stepAction}>
           <Button

--- a/YCAI/src/components/dashboard/Sidebar.tsx
+++ b/YCAI/src/components/dashboard/Sidebar.tsx
@@ -105,6 +105,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ currentView }) => {
     <Box
       style={{
         position: 'sticky',
+        top: theme.spacing(3),
       }}
     >
       <Box

--- a/YCAI/src/components/dashboard/Sidebar.tsx
+++ b/YCAI/src/components/dashboard/Sidebar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   Box,
   List,
@@ -7,15 +8,15 @@ import {
   useTheme,
   Divider,
 } from '@material-ui/core';
-import * as React from 'react';
 import { useTranslation } from 'react-i18next';
+
+import { ContentCreator } from '@shared/models/ContentCreator';
 import { CurrentView, doUpdateCurrentView } from '../../utils/location.utils';
 import { UserProfileBox } from './UserProfileBox';
 import LabIcon from '../common/icons/LabIcon';
 import AnalyticsIcon from '../common/icons/AnalyticsIcon';
 import SettingsIcon from '../common/icons/SettingsIcon';
 import YCAILogo from '../common/YCAILogo';
-
 
 const useStyles = makeStyles((theme) => ({
   routesList: {
@@ -95,9 +96,10 @@ const toMenuItem = (
 
 interface SidebarProps {
   currentView: CurrentView;
+  profile?: ContentCreator;
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ currentView }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ currentView, profile }) => {
   const { t } = useTranslation();
   const classes = useStyles();
   const theme = useTheme();
@@ -120,41 +122,46 @@ export const Sidebar: React.FC<SidebarProps> = ({ currentView }) => {
         <YCAILogo height={24} />
       </Box>
 
-      <UserProfileBox />
-      <Divider light className={classes.divider}/>
+      {profile && (
+        <>
+          <UserProfileBox />
 
-      <List className={classes.routesList} disablePadding={true}>
-        {[
-          {
-            title: t('routes:lab_title_short'),
-            icon: LabIcon,
-            views: ['lab', 'labEdit'] as Array<CurrentView['view']>,
-          },
-          {
-            title: t('routes:analytics'),
-            icon: AnalyticsIcon,
-            views: ['statistics'] as Array<CurrentView['view']>,
-          },
-          {
-            title: t('routes:settings'),
-            icon: SettingsIcon,
-            views: ['settings'] as Array<CurrentView['view']>,
-          },
-        ].map((opts) =>
-          toMenuItem(
-            {
-              ...opts,
-              iconClassName: classes.listItemIcon,
-              iconColor: theme.palette.primary.main,
-              iconSelectedColor: theme.palette.common.white,
-              className: classes.listItem,
-              notSelectedClassName: classes.listItemNotSelected,
-              selectedClassName: classes.listItemSelected,
-            },
-            currentView
-          )
-        )}
-      </List>
+          <Divider light className={classes.divider}/>
+
+          <List className={classes.routesList} disablePadding={true}>
+            {[
+              {
+                title: t('routes:lab_title_short'),
+                icon: LabIcon,
+                views: ['lab', 'labEdit'] as Array<CurrentView['view']>,
+              },
+              {
+                title: t('routes:analytics'),
+                icon: AnalyticsIcon,
+                views: ['analytics'] as Array<CurrentView['view']>,
+              },
+              {
+                title: t('routes:settings'),
+                icon: SettingsIcon,
+                views: ['settings'] as Array<CurrentView['view']>,
+              },
+            ].map((opts) =>
+              toMenuItem(
+                {
+                  ...opts,
+                  iconClassName: classes.listItemIcon,
+                  iconColor: theme.palette.primary.main,
+                  iconSelectedColor: theme.palette.common.white,
+                  className: classes.listItem,
+                  notSelectedClassName: classes.listItemNotSelected,
+                  selectedClassName: classes.listItemSelected,
+                },
+                currentView
+              )
+            )}
+          </List>
+        </>
+      )}
     </Box>
   );
 };

--- a/YCAI/src/components/dashboard/TokenLoginModal.tsx
+++ b/YCAI/src/components/dashboard/TokenLoginModal.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useTranslation } from 'react-i18next';
+import { isLeft } from 'fp-ts/lib/Either';
+
+import { assignAccessToken } from '../../state/dashboard/creator.commands';
+import { doUpdateCurrentView } from '../../utils/location.utils';
+
+const useStyles = makeStyles(theme => ({
+  content: {
+    minWidth: '500px',
+  },
+  error: {
+    marginTop: theme.spacing(1),
+  }
+}));
+
+interface TokenLoginModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const TokenLoginModal: React.FC<TokenLoginModalProps> = ({
+  isOpen,
+  onClose,
+}) => {
+  const { t } = useTranslation();
+  const classes = useStyles();
+  const [token, setToken] = React.useState('');
+  const [error, setError] = React.useState('');
+
+  const handleSubmit = (): void => {
+    void assignAccessToken({ token })().then((resp) => {
+      if (isLeft(resp)) {
+        setError(t('link_account:token_authentication_failed'));
+      } else {
+        onClose();
+        void doUpdateCurrentView({ view: 'analytics' })();
+      }
+    });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === 'Enter') {
+      void handleSubmit();
+    }
+  };
+
+  return (
+    <Dialog
+      open={isOpen}
+      onClose={onClose}
+    >
+      <DialogTitle>
+        {t('link_account:token_modal_title')}
+      </DialogTitle>
+      <DialogContent className={classes.content}>
+        <DialogContentText>
+          {t('link_account:token_modal_description')}
+        </DialogContentText>
+        <TextField
+          fullWidth
+          label={t('settings:access_token')}
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        {error && (
+          <DialogContentText className={classes.error}>
+            {error}
+          </DialogContentText>
+        )}
+      </DialogContent>
+
+      <DialogActions>
+        <Button onClick={onClose}>
+          {t('actions:cancel')}
+        </Button>
+        <Button color="primary" onClick={handleSubmit}>
+          {t('link_account:token_modal_submit')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default TokenLoginModal;

--- a/YCAI/src/i18n/en-US.ts
+++ b/YCAI/src/i18n/en-US.ts
@@ -93,7 +93,12 @@ const resources: CustomTypeOptions['resources'] = {
       "Please double-check that you have published the code\nin your channel's description and try again.",
     go_back_to_step_one_hint:
       'If the verification keeps failing, <1>go back to step one</1> and make sure\nyou have pasted the correct URL of your YouTube channel.',
-    channel_not_found: "We couldn't find a channel with the ID you provided.\nPlease make sure the URL or ID you pasted is correct."
+    channel_not_found: "We couldn't find a channel with the ID you provided.\nPlease make sure the URL or ID you pasted is correct.",
+    already_have_token: 'Or <1>click here</1> if you already have an access token.',
+    token_modal_title: 'Authenticate with an access token',
+    token_modal_description: 'If you already have an access token, paste it below:',
+    token_modal_submit: 'Authenticate',
+    token_authentication_failed: 'Authentication failed, please check your access token.',
   },
   youtube: {
     title: 'Youtube',

--- a/YCAI/src/utils/location.utils.ts
+++ b/YCAI/src/utils/location.utils.ts
@@ -7,14 +7,14 @@ import {
 export type CurrentView =
   | { view: 'labEdit'; videoId: string }
   | { view: 'lab' }
-  | { view: 'statistics' }
+  | { view: 'analytics' }
   | { view: 'settings' }
   | { view: 'linkAccount' }
   | { view: 'index' };
 
 const labEditRegex = /^\/lab\/([^/]+)$/;
 const labRegex = /^\/lab\/$/;
-const statisticsRegex = /^\/statistics\/$/;
+const analyticsRegex = /^\/analytics\/$/;
 const settingsRegex = /^\/settings\/$/;
 const linkAccountRegex = /^\/link-account\/$/;
 
@@ -32,9 +32,9 @@ export function locationToView(location: HistoryLocation): CurrentView {
     return { view: 'lab' };
   }
 
-  const communityMatch = currentPath.match(statisticsRegex);
+  const communityMatch = currentPath.match(analyticsRegex);
   if (communityMatch !== null) {
-    return { view: 'statistics' };
+    return { view: 'analytics' };
   }
 
   const settingsMatch = currentPath.match(settingsRegex);
@@ -66,11 +66,11 @@ export function viewToLocation(view: CurrentView): HistoryLocation {
           path: '/lab/',
         },
       };
-    case 'statistics':
+    case 'analytics':
       return {
         pathname: `index.html`,
         search: {
-          path: '/statistics/',
+          path: '/analytics/',
         },
       };
     case 'settings':

--- a/YCAI/typings/react-i18next/index.d.ts
+++ b/YCAI/typings/react-i18next/index.d.ts
@@ -72,6 +72,11 @@ declare module 'react-i18next' {
         verification_failed_hint: string;
         go_back_to_step_one_hint: string;
         channel_not_found: string;
+        already_have_token: string;
+        token_modal_title: string;
+        token_modal_description: string;
+        token_modal_submit: string;
+        token_authentication_failed: string;
       };
       youtube: {
         title: string;


### PR DESCRIPTION
This pull request removes the side-bar links during the authentication flow, and, to allow authenticating with an access token, adds a link that opens a modal with the access token input.

Closes https://github.com/tracking-exposed/yttrex/issues/216 and https://github.com/tracking-exposed/yttrex/issues/188

![login with token](https://user-images.githubusercontent.com/1460499/144889322-c1cd9986-c49c-401a-81dd-3011e27e20c7.gif)
