### PR TITLE
Nudge users into opting in to data donation

### DIFF
--- a/YCAI/src/background/index.ts
+++ b/YCAI/src/background/index.ts
@@ -2,7 +2,7 @@ import { ContentCreator } from '@shared/models/ContentCreator';
 import { sequenceS } from 'fp-ts/lib/Apply';
 import * as E from 'fp-ts/lib/Either';
 import * as O from 'fp-ts/lib/Option';
-import { pipe } from 'fp-ts/lib/pipeable';
+import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
 import { config } from '../config';
 import * as Messages from '../models/Messages';
@@ -37,6 +37,9 @@ export const getStorageKey = (type: string): string => {
     case Messages.GetContentCreator.value:
     case Messages.UpdateContentCreator.value:
       return constants.CONTENT_CREATOR;
+    case Messages.GetDonationOptInNudgeStatus.value:
+    case Messages.SetDonationOptInNudgeStatus.value:
+      return constants.DONATION_OPT_IN_NUDGE_STATUS_KEY;
     default:
       return '';
   }
@@ -119,6 +122,7 @@ const getMessageHandler = <
     case Messages.GetKeypair.value:
     case Messages.GetAuth.value:
     case Messages.GetContentCreator.value:
+    case Messages.GetDonationOptInNudgeStatus.value:
       return pipe(
         db.get<any>(getStorageKey(r.type)),
         TE.mapLeft(toMessageHandlerError),
@@ -157,6 +161,7 @@ const getMessageHandler = <
     // updates
     case Messages.UpdateContentCreator.value:
     case Messages.UpdateAuth.value:
+    case Messages.SetDonationOptInNudgeStatus.value:
       return pipe(
         db.update(getStorageKey(r.type), r.payload),
         TE.mapLeft(toMessageHandlerError),

--- a/YCAI/src/components/injected/DonationOptInNudger.tsx
+++ b/YCAI/src/components/injected/DonationOptInNudger.tsx
@@ -1,0 +1,114 @@
+import React, { useState, useEffect } from 'react';
+import { WithQueries } from 'avenger/lib/react';
+import { fold } from 'avenger/lib/QueryResult';
+import { useTranslation } from 'react-i18next';
+import { Button, Link, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/styles';
+
+import { settings } from '../../state/popup.queries';
+import { donationOptInNudgeStatus } from '../../state/injected.queries';
+import { setDonationOptInNudgeStatus } from '../../state/injected.commands';
+import { updateSettings } from '../../state/popup.commands';
+import { YCAITheme } from '../../theme';
+import { DATA_DONATION_LEARN_MORE_URL } from '../../constants';
+
+const useStyles = makeStyles<YCAITheme>(theme => ({
+  box: {
+    border: `1px solid ${theme.palette.divider}`,
+    padding: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+  },
+  text: {
+    fontSize: '1.5rem',
+    marginBottom: theme.spacing(1),
+  },
+}));
+
+const DonationOptInNudger: React.FC = () =>
+  <WithQueries
+    queries={{ settings, donationOptInNudgeStatus }}
+    render={fold(() => null, () => null, ({ settings, donationOptInNudgeStatus }) => {
+      const { t } = useTranslation();
+      const classes = useStyles();
+
+      const [showNudge, setShowNudge] = useState(false);
+
+      useEffect(() => {
+        const { showNudgeTimes } = donationOptInNudgeStatus;
+
+        if (showNudgeTimes.length === 0) {
+          return;
+        }
+
+        const [nextNudgeTime] = showNudgeTimes;
+
+        const now = Date.now();
+
+        if (now >= nextNudgeTime) {
+          setShowNudge(true);
+          return;
+        }
+
+        const timeout = setTimeout(() => {
+          setShowNudge(true);
+        }, nextNudgeTime - now);
+
+        return () => clearTimeout(timeout);
+      }, []);
+
+      const handleNotNowClicked = (): void => {
+        // clicking on not now should hide the nudge until the next time stored
+        // in the local storage
+        setShowNudge(false);
+        const { showNudgeTimes: [, ...remaining] } = donationOptInNudgeStatus;
+        void setDonationOptInNudgeStatus({ showNudgeTimes: remaining })();
+      };
+
+      const handleAgreeClicked = (): void => {
+        void updateSettings({
+          ...settings,
+          independentContributions: {
+            ...settings.independentContributions,
+            enable: true,
+          },
+        })();
+        setShowNudge(false);
+      };
+
+      if (!showNudge || settings.independentContributions.enable) {
+        return null;
+      }
+
+      return (
+        <div className={classes.box}>
+          <Typography className={classes.text}>
+            {t('settings:nudge_donation_opt_in')}
+            &nbsp;
+            <Link
+              href={DATA_DONATION_LEARN_MORE_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {t('settings:nudge_learn_more')}
+            </Link>
+          </Typography>
+
+          <Button
+            color="secondary"
+            onClick={handleNotNowClicked}
+          >
+            {t('settings:nudge_not_now')}
+          </Button>
+          <Button
+            color="primary"
+            onClick={handleAgreeClicked}
+          >
+            {t('settings:nudge_agree')}
+          </Button>
+        </div>
+      );
+    }
+    )}
+  />;
+
+export default DonationOptInNudger;

--- a/YCAI/src/components/injected/YTContributionInfoBox.tsx
+++ b/YCAI/src/components/injected/YTContributionInfoBox.tsx
@@ -5,7 +5,6 @@ import { WithQueries } from 'avenger/lib/react';
 
 import { ErrorBox } from '../../components/common/ErrorBox';
 import { LazyFullSizeLoader } from '../../components/common/FullSizeLoader';
-import { config } from '../../config';
 import { Keypair, Settings } from '../../models/Settings';
 import * as dataDonation from '../../providers/dataDonation.provider';
 import { keypair } from '../../state/popup.queries';
@@ -45,8 +44,7 @@ const YTContributionInfoBoxComponent: React.FC<{
     };
   }, [settings]);
 
-  // don't render anything in production
-  if (config.NODE_ENV === 'production') {
+  if (!settings.independentContributions.showUI) {
     return null;
   }
 

--- a/YCAI/src/components/injected/YTVideoPage.tsx
+++ b/YCAI/src/components/injected/YTVideoPage.tsx
@@ -17,6 +17,7 @@ import { Settings } from '../../models/Settings';
 import { TabPanel } from '../common/TabPanel';
 import { Tab } from '../common/Tab';
 import { VideoRecommendations } from './VideoRecommendations';
+import DonationOptInNudger from './DonationOptInNudger';
 
 const logger = GetLogger('yt-video-recommendations');
 
@@ -159,6 +160,8 @@ export const YTVideoPage: React.FC<{
           />
         </Tabs>
       </AppBar>
+
+      <DonationOptInNudger />
 
       <TabPanel value={currentTab} index={CC_TAB_INDEX}>
         {currentVideoId === undefined ? (

--- a/YCAI/src/components/popup/Popup.tsx
+++ b/YCAI/src/components/popup/Popup.tsx
@@ -77,7 +77,7 @@ export const Popup: React.FC = () => {
   const classes = useStyles();
 
   const version = config.VERSION;
-  const timeago = formatDistance(
+  const timeAgo = formatDistance(
     parseISO(config.BUILD_DATE),
     new Date(),
     {
@@ -119,7 +119,7 @@ export const Popup: React.FC = () => {
                   justifyContent="center"
                 >
                   <Typography variant="caption">
-                    {t('popup:version', { version, date: timeago })}
+                    {t('popup:version', { version, date: timeAgo })}
                   </Typography>
                   {config.NODE_ENV === 'development' ? (
                     <Typography
@@ -155,7 +155,6 @@ export const Popup: React.FC = () => {
           )
         )}
       />
-      {/* </Grid> */}
     </Card>
   );
 };

--- a/YCAI/src/components/popup/Settings.tsx
+++ b/YCAI/src/components/popup/Settings.tsx
@@ -1,16 +1,19 @@
+import React from 'react';
 import {
   Divider,
   FormControl,
   FormControlLabel,
   FormLabel,
+  Link,
   makeStyles,
   Switch,
   Typography,
 } from '@material-ui/core';
-import * as React from 'react';
+import { Folder as FolderIcon } from '@material-ui/icons';
 import { useTranslation } from 'react-i18next';
 import * as models from '../../models';
 import { generateKeypair, updateSettings } from '../../state/popup.commands';
+import { DATA_DONATION_LEARN_MORE_URL } from '../../constants';
 
 const useStyles = makeStyles((theme) => ({
   divider: {
@@ -30,6 +33,16 @@ const useStyles = makeStyles((theme) => ({
   marginRight: {
     marginRight: 15,
   },
+  learnMore: {
+    alignItems: 'center',
+    display: 'flex',
+    lineHeight: 1,
+    marginTop: theme.spacing(1),
+    marginLeft: -6,
+    '& svg': {
+      height: 16,
+    }
+  }
 }));
 
 interface SettingsProps {
@@ -104,6 +117,14 @@ const Settings: React.FC<SettingsProps> = ({ settings }) => {
               <Typography display="block">
                 {t('settings:contributeToIndependentStatsHint')}
               </Typography>
+              <Link
+                className={classes.learnMore}
+                href={DATA_DONATION_LEARN_MORE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <FolderIcon /> {t('settings:data_donation_learn_more')}
+              </Link>
               <br />
               <Divider light />
             </FormLabel>

--- a/YCAI/src/components/popup/Settings.tsx
+++ b/YCAI/src/components/popup/Settings.tsx
@@ -44,7 +44,6 @@ const Settings: React.FC<SettingsProps> = ({ settings }) => {
     <>
       <FormControlLabel
         className={classes.controlLabel}
-        disabled={!settings.active}
         control={
           <Switch
             className={classes.marginRight}
@@ -76,7 +75,6 @@ const Settings: React.FC<SettingsProps> = ({ settings }) => {
       <FormControl component="fieldset">
         <FormControlLabel
           className={classes.controlLabel}
-          disabled={!settings.active}
           control={
             <Switch
               className={classes.marginRight}

--- a/YCAI/src/constants/index.ts
+++ b/YCAI/src/constants/index.ts
@@ -3,3 +3,6 @@ export const PUBLIC_KEYPAIR = 'public-keypair';
 
 export const AUTH_KEY = 'auth';
 export const CONTENT_CREATOR = 'content-creator';
+export const DONATION_OPT_IN_NUDGE_STATUS_KEY = 'donation-opt-in-nudge-status';
+
+export const DATA_DONATION_LEARN_MORE_URL = 'https://youchoose.ai';

--- a/YCAI/src/i18n/en-US.ts
+++ b/YCAI/src/i18n/en-US.ts
@@ -162,6 +162,12 @@ const resources: CustomTypeOptions['resources'] = {
     access_token_title: 'Your access token',
     access_token_description: 'This access token allows this browser to access your profile on YouChoose.\nYou can share it with team-members to give them access to the YouChoose dashboard.',
     access_token: 'Access Token',
+    data_donation_learn_more: 'Learn more',
+    nudge_donation_opt_in: 'Please consider donating anonymous data to help us understand the YouTube algorithm.',
+    nudge_learn_more: 'Learn more.',
+    nudge_not_now: 'Not now',
+    nudge_agree: 'I agree',
+
   },
   ytVideoPage: {
     firstTab: 'Creator Recommendations',

--- a/YCAI/src/models/Messages.ts
+++ b/YCAI/src/models/Messages.ts
@@ -3,7 +3,7 @@ import { ContentCreator } from '@shared/models/ContentCreator';
 import { pipe } from 'fp-ts/lib/function';
 import * as R from 'fp-ts/lib/Record';
 import * as t from 'io-ts';
-import { Keypair, Settings } from './Settings';
+import { Keypair, Settings, OptInNudgeStatus } from './Settings';
 
 // keypair
 export const GetKeypair = t.literal('GetKeypair');
@@ -31,6 +31,9 @@ export const Update = t.literal('update');
 export const RecommendationsFetch = t.literal('recommendationsFetch');
 export const ServerLookup = t.literal('serverLookup');
 
+export const GetDonationOptInNudgeStatus = t.literal('GetDonationOptInNudgeStatus');
+export const SetDonationOptInNudgeStatus = t.literal('SetDonationOptInNudgeStatus');
+
 export const MessageType = t.union(
   [
     GetSettings,
@@ -44,6 +47,8 @@ export const MessageType = t.union(
     GetContentCreator,
     UpdateContentCreator,
     ErrorOccurred,
+    GetDonationOptInNudgeStatus,
+    SetDonationOptInNudgeStatus,
   ],
   'MessageType'
 );
@@ -135,6 +140,8 @@ export const Messages = MessagesAPI({
   [ReloadExtension.value]: { payload: t.any, response: t.undefined },
   [ServerLookup.value]: { payload: t.any, response: t.undefined },
   [ErrorOccurred.value]: { payload: t.any, response: t.any },
+  [GetDonationOptInNudgeStatus.value]: { payload: t.void, response: OptInNudgeStatus },
+  [SetDonationOptInNudgeStatus.value]: { payload: OptInNudgeStatus, response: OptInNudgeStatus },
 });
 
 export type Messages = typeof Messages;

--- a/YCAI/src/models/Settings.ts
+++ b/YCAI/src/models/Settings.ts
@@ -1,4 +1,3 @@
-import { Video } from '@shared/models/Video';
 import * as t from 'io-ts';
 
 export const Keypair = t.strict(
@@ -17,30 +16,21 @@ export type Keypair = t.TypeOf<typeof Keypair>;
  */
 export const Settings = t.strict(
   {
-    active: t.boolean,
     enhanceYouTubeExperience: t.boolean,
     independentContributions: t.strict({
       enable: t.boolean,
       showUI: t.boolean,
     }),
-    svg: t.boolean,
-    videorep: t.boolean,
-    playhide: t.boolean,
-    alphabeth: t.boolean,
-    edit: t.union([Video, t.null]),
   },
   'AccountSettings'
 );
 
 export const getDefaultSettings = (): Settings => ({
-  active: true,
   enhanceYouTubeExperience: true,
-  svg: false,
-  videorep: true,
-  playhide: false,
-  alphabeth: false,
-  independentContributions: { enable: true, showUI: false },
-  edit: null,
+  independentContributions: {
+    enable: true,
+    showUI: process.env.NODE_ENV === 'development',
+  },
 });
 
 export type Settings = t.TypeOf<typeof Settings>;

--- a/YCAI/src/models/Settings.ts
+++ b/YCAI/src/models/Settings.ts
@@ -28,9 +28,25 @@ export const Settings = t.strict(
 export const getDefaultSettings = (): Settings => ({
   enhanceYouTubeExperience: true,
   independentContributions: {
-    enable: true,
+    enable: false,
     showUI: process.env.NODE_ENV === 'development',
   },
 });
 
 export type Settings = t.TypeOf<typeof Settings>;
+
+export const OptInNudgeStatus = t.strict({
+  showNudgeTimes: t.array(t.number),
+}, 'OptInNudgeStatus');
+
+export type OptInNudgeStatus = t.TypeOf<typeof OptInNudgeStatus>;
+
+export const getInitialOptInNudgeStatus = (): OptInNudgeStatus => ({
+  showNudgeTimes: [
+    Date.now() + 1000 * 60 * 15,            // 15 minutes from now
+    Date.now() + 1000 * 60 * 60 * 24 * 7,   // 1 week from now
+    Date.now() + 1000 * 60 * 60 * 24 * 7,   // 2 weeks from now
+    Date.now() + 1000 * 60 * 60 * 24 * 30,  // 1 month from now
+    Date.now() + 1000 * 60 * 60 * 24 * 365, // 2 months from now
+  ],
+});

--- a/YCAI/src/state/injected.commands.ts
+++ b/YCAI/src/state/injected.commands.ts
@@ -1,0 +1,11 @@
+import { command } from 'avenger';
+
+import { sendMessage } from '../providers/browser.provider';
+import { OptInNudgeStatus } from '../models/Settings';
+import { Messages } from '../models/Messages';
+import { donationOptInNudgeStatus } from './injected.queries';
+
+export const setDonationOptInNudgeStatus = command(
+  (payload: OptInNudgeStatus) => sendMessage(Messages.SetDonationOptInNudgeStatus)(payload),
+  { donationOptInNudgeStatus }
+);

--- a/YCAI/src/state/injected.queries.ts
+++ b/YCAI/src/state/injected.queries.ts
@@ -1,0 +1,25 @@
+import { pipe } from 'fp-ts/lib/function';
+import { chain, map, right } from 'fp-ts/lib/TaskEither';
+import { available, queryShallow } from 'avenger';
+
+import { Messages } from '../models/Messages';
+import { getInitialOptInNudgeStatus } from '../models/Settings';
+import { sendMessage } from '../providers/browser.provider';
+
+export const donationOptInNudgeStatus = queryShallow(
+  () => pipe(
+    sendMessage(Messages.GetDonationOptInNudgeStatus)(),
+    chain((status) => {
+      if (!status) {
+        const initialStatus = getInitialOptInNudgeStatus();
+        return pipe(
+          sendMessage(Messages.SetDonationOptInNudgeStatus)(initialStatus),
+          map(() => initialStatus)
+        );
+      }
+      return right(status);
+    }
+    )
+  ),
+  available,
+);

--- a/YCAI/typings/react-i18next/index.d.ts
+++ b/YCAI/typings/react-i18next/index.d.ts
@@ -139,6 +139,11 @@ declare module 'react-i18next' {
         access_token: string;
         access_token_title: string;
         access_token_description: string;
+        data_donation_learn_more: string;
+        nudge_donation_opt_in: string;
+        nudge_learn_more: string;
+        nudge_not_now: string;
+        nudge_agree: string;
       };
       videos: {
         no_results: string;


### PR DESCRIPTION
This features aims to politely ask users for their consent to data donation.

A notification appears in the YouChoose injected page:
![image](https://user-images.githubusercontent.com/1460499/145431153-ed88b913-5d6f-4acf-b338-5833bc597227.png)

It is (currently) set to appear 15 minutes after the first time YouTube is visited with the YCAI extension enabled. It will keep appearing on page reload unless "Not now" or "I agree" is clicked.

If the user clicks on "Not now", he will be reminded again after 1 week, then 2 weeks, 1 month, 2 months and then we give up.

