### PR TITLE
fix: defined summary queries for tik tok

### DIFF
--- a/packages/taboule/public/index.html
+++ b/packages/taboule/public/index.html
@@ -19,8 +19,14 @@
           <option value="personalVideos">Personal Videos</option>
           <option value="personalHomes">Personal Homes</option>
           <option value="personalAds">Personal ADS</option>
-          <option value="getExperimentById" selected>Compare Experiment</option>
-          <option value="getExperimentList" selected>Experiment list</option>
+          <option value="getExperimentById">Compare Experiment</option>
+          <option value="getExperimentList">Experiment list</option>
+          <option value="tikTokPersonalHTMLSummary" selected>
+            TikTok Personal HTML Summary
+          </option>
+          <option value="tikTokPersonalMetadataSummary" selected>
+            TikTok Personal Metadata Summary
+          </option>
         </select>
         <div id="taboule-show-inputs" style="display: inline">
           <label>Show Params Inputs</label>

--- a/packages/taboule/src/components/ErrorOverlay.tsx
+++ b/packages/taboule/src/components/ErrorOverlay.tsx
@@ -1,19 +1,8 @@
-import {
-  Box,
-  Card,
-  CardContent,
-  CardHeader,
-  List,
-  ListItem,
-  ListItemText,
-  Typography,
-  useTheme,
-} from '@material-ui/core';
-import { isValidationError } from '@shared/errors/ValidationError';
+import { Box } from '@material-ui/core';
+import { ErrorBox } from '@shared/components/Error/ErrorBox';
 import * as React from 'react';
 
 export const ErrorOverlay: React.FC<Error> = (error) => {
-  const theme = useTheme();
   return (
     <Box
       display={'flex'}
@@ -27,29 +16,11 @@ export const ErrorOverlay: React.FC<Error> = (error) => {
     >
       <Box
         style={{
-          textAlign: 'center',
           margin: 'auto',
+          width: '100%',
         }}
       >
-        <Card variant="outlined">
-          <CardHeader
-            title={error.name}
-            subheader={error.message}
-            color={theme.palette.error.main}
-          />
-          <CardContent>
-            <Typography variant="h6">Details</Typography>
-            {isValidationError(error) ? (
-              <List>
-                {error.details.map((d) => (
-                  <ListItem key={d}>
-                    <ListItemText>{d}</ListItemText>
-                  </ListItem>
-                ))}
-              </List>
-            ) : null}
-          </CardContent>
-        </Card>
+        {ErrorBox(error)}
       </Box>
     </Box>
   );

--- a/packages/taboule/src/config.tsx
+++ b/packages/taboule/src/config.tsx
@@ -19,6 +19,10 @@ import {
   SearchMetadata,
   VideoMetadata,
 } from '@shared/models/contributor/ContributorPersonalStats';
+import {
+  SummaryHTMLMetadata,
+  SummaryMetadata,
+} from '@shared/models/contributor/ContributorPersonalSummary';
 import { GuardoniExperiment, Metadata } from '@shared/models/Metadata';
 import DeleteButton from 'components/buttons/DeleteButton';
 import { formatDistanceToNow } from 'date-fns';
@@ -45,32 +49,24 @@ interface TabouleConfiguration {
   personalHomes: TabouleQueryConfiguration<HomeMetadata>;
   personalSearches: TabouleQueryConfiguration<SearchMetadata>;
   personalVideos: TabouleQueryConfiguration<VideoMetadata>;
+  tikTokPersonalHTMLSummary: TabouleQueryConfiguration<SummaryHTMLMetadata>;
+  tikTokPersonalMetadataSummary: TabouleQueryConfiguration<SummaryMetadata>;
 }
 
-const defaultChannelId = 'c14bb994-d13d-4a5e-bdee-a62976facca9';
-const defaultPublicKey = '39kM5AyUrGXZaJPseoyKuNT2968Ee5SY6fbWxWcG1ivC';
 export const defaultParams = {
-  ccRelatedUsers: {
-    channelId: defaultChannelId,
-  },
+  ccRelatedUsers: {},
   getExperimentById: {},
   getExperimentList: {
     type: 'comparison',
     key: 'fuffa',
     // this is the default as per 'yarn backend watch'
   },
-  personalHomes: {
-    publicKey: defaultPublicKey,
-  },
-  personalSearches: {
-    publicKey: defaultPublicKey,
-  },
-  personalVideos: {
-    publicKey: defaultPublicKey,
-  },
-  personalAds: {
-    publicKey: defaultPublicKey,
-  },
+  personalHomes: {},
+  personalSearches: {},
+  personalVideos: {},
+  personalAds: {},
+  tikTokPersonalHTMLSummary: {},
+  tikTokPersonalMetadataSummary: {},
 };
 
 const channelIdInput = (
@@ -89,7 +85,7 @@ const channelIdInput = (
         control={
           <Input
             name="channelId"
-            value={params.channelId ?? defaultChannelId}
+            value={params.channelId ?? ''}
             onChange={(e) =>
               setParams({ ...params, publicKey: e.target.value })
             }
@@ -116,7 +112,7 @@ const publicKeyInput = (
         control={
           <Input
             name="publicKey"
-            value={params.publicKey ?? defaultPublicKey}
+            value={params.publicKey ?? ''}
             onChange={(e) =>
               setParams({ ...params, publicKey: e.target.value })
             }
@@ -394,6 +390,51 @@ export const defaultConfiguration = (
           field: 'actions',
           minWidth: 200,
           renderCell: personalMetadataActions(commands, params),
+        },
+      ],
+    },
+    tikTokPersonalHTMLSummary: {
+      inputs: publicKeyInput,
+      columns: [
+        {
+          field: 'id',
+          minWidth: 200,
+        },
+        {
+          field: 'timelineId',
+          minWidth: 200,
+        },
+        {
+          field: 'href',
+          minWidth: 200,
+        },
+        {
+          field: 'savingTime',
+          minWidth: 200,
+        },
+      ],
+    },
+    tikTokPersonalMetadataSummary: {
+      inputs: publicKeyInput,
+      columns: [
+        {
+          field: 'id',
+          minWidth: 200,
+        },
+        {
+          field: 'timelineId',
+          minWidth: 200,
+        },
+        {
+          field: 'author',
+          minWidth: 200,
+          renderCell: (props) => {
+            return <Typography>{(props.value as any)?.name ?? ''}</Typography>;
+          },
+        },
+        {
+          field: 'relative',
+          minWidth: 200,
         },
       ],
     },

--- a/packages/taboule/src/state/queries.ts
+++ b/packages/taboule/src/state/queries.ts
@@ -5,6 +5,10 @@ import {
   SearchMetadata,
   VideoMetadata,
 } from '@shared/models/contributor/ContributorPersonalStats';
+import {
+  SummaryHTMLMetadata,
+  SummaryMetadata,
+} from '@shared/models/contributor/ContributorPersonalSummary';
 import { SearchQuery } from '@shared/models/http/SearchQuery';
 import { GuardoniExperiment, Metadata } from '@shared/models/Metadata';
 import { GetAPI } from '@shared/providers/api.provider';
@@ -33,6 +37,9 @@ export interface TabouleQueries {
   personalAds: EndpointQuery<any>;
   personalHomes: EndpointQuery<HomeMetadata>;
   personalVideos: EndpointQuery<VideoMetadata>;
+  // tik tok
+  tikTokPersonalHTMLSummary: EndpointQuery<SummaryHTMLMetadata>;
+  tikTokPersonalMetadataSummary: EndpointQuery<SummaryMetadata>;
 }
 
 interface GetTabouleQueriesProps {
@@ -174,6 +181,42 @@ export const GetTabouleQueries = ({
     available
   );
 
+  const tikTokPersonalHTMLSummary = queryStrict<
+    SearchRequestInput,
+    APIError,
+    Results<SummaryHTMLMetadata>
+  >(
+    (input) =>
+      pipe(
+        API.v1.Public.GetPersonalSummaryByPublicKey({
+          ...input,
+        }),
+        TE.map((content) => ({
+          total: content.htmls.length,
+          content: content.htmls,
+        }))
+      ),
+    available
+  );
+
+  const tikTokPersonalMetadataSummary = queryStrict<
+    SearchRequestInput,
+    APIError,
+    Results<SummaryMetadata>
+  >(
+    (input) =>
+      pipe(
+        API.v1.Public.GetPersonalSummaryByPublicKey({
+          ...input,
+        }),
+        TE.map((content) => ({
+          total: content.metadata.length,
+          content: content.metadata,
+        }))
+      ),
+    available
+  );
+
   return {
     ccRelatedUsers,
     getExperimentById,
@@ -182,5 +225,7 @@ export const GetTabouleQueries = ({
     personalAds,
     personalVideos,
     personalSearches,
+    tikTokPersonalHTMLSummary,
+    tikTokPersonalMetadataSummary,
   };
 };

--- a/packages/taboule/src/state/types.ts
+++ b/packages/taboule/src/state/types.ts
@@ -1,0 +1,17 @@
+import * as t from 'io-ts';
+
+export const TabouleQueryKey = t.union(
+  [
+    t.literal('ccRelatedUsers'),
+    t.literal('getExperimentById'),
+    t.literal('getExperimentList'),
+    t.literal('personalSearches'),
+    t.literal('personalVideos'),
+    t.literal('personalHomes'),
+    t.literal('personalAds'),
+    t.literal('tikTokPersonalHTMLSummary'),
+    t.literal('tikTokPersonalMetadataSummary'),
+  ],
+  'TabouleQueryKey'
+);
+export type TabouleQueryKey = t.TypeOf<typeof TabouleQueryKey>;

--- a/packages/taboule/tsconfig.json
+++ b/packages/taboule/tsconfig.json
@@ -30,11 +30,11 @@
       "@shared/*": ["../../../shared/src/*"]
     }
   },
-  "references": [{ "path": "../../shared" }],
   "include": ["./src", "./typings"],
   "ts-node": {
     "compilerOptions": {
       "module": "CommonJS"
     }
-  }
+  },
+  "references": [{ "path": "../../shared" }]
 }

--- a/shared/src/components/Error/ErrorBoundary.tsx
+++ b/shared/src/components/Error/ErrorBoundary.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ErrorBox } from './ErrorBox';
 
 interface ErrorState {
   error?: Error;
@@ -29,14 +30,7 @@ export class ErrorBoundary extends React.Component<any, ErrorState> {
     if (this.state.error !== undefined) {
       // You can render any custom fallback UI
       // eslint-disable-next-line no-console
-      return (
-        <div>
-          <h1>Un error occurred: {this.state.error.name}</h1>
-          <pre style={{ backgroundColor: 'white' }}>
-            <code>{JSON.stringify(this.state.error, null, 2)}</code>
-          </pre>
-        </div>
-      );
+      return ErrorBox(this.state.error);
     }
     return this.props.children;
   }

--- a/shared/src/components/Error/ErrorBox.tsx
+++ b/shared/src/components/Error/ErrorBox.tsx
@@ -1,7 +1,6 @@
-import { Card, CardContent, Typography } from '@material-ui/core';
+import { Box, Card, CardContent, Typography } from '@material-ui/core';
 import { Alert, AlertTitle } from '@material-ui/lab';
 import * as React from 'react';
-import { isAPIError } from '../../errors/APIError';
 
 // todo: add NODE_ENV as parameter
 export const ErrorBox = (e: unknown): React.ReactElement<any, string> => {
@@ -11,10 +10,12 @@ export const ErrorBox = (e: unknown): React.ReactElement<any, string> => {
     <Card>
       <Alert severity="error">
         <AlertTitle>{e instanceof Error ? e.name : 'Error'}</AlertTitle>
-        <p>{e instanceof Error ? e.message : 'Unknown error'}</p>
-        {isAPIError(e) ? (
+        <Typography variant="subtitle1">
+          {e instanceof Error ? e.message : 'Unknown error'}
+        </Typography>
+        {Array.isArray((e as any).details) ? (
           <ul>
-            {(e.details ?? []).map((d) => (
+            {((e as any).details as string[]).map((d) => (
               <li key={d}>{d}</li>
             ))}
           </ul>
@@ -22,10 +23,14 @@ export const ErrorBox = (e: unknown): React.ReactElement<any, string> => {
       </Alert>
 
       <CardContent>
-        <Typography variant="h6">Debug</Typography>
-        <pre style={{ backgroundColor: 'white' }}>
-          <code>{JSON.stringify(e, null, 2)}</code>
-        </pre>
+        {process.env.NODE_ENV === 'development' ? (
+          <Box>
+            <Typography variant="h6">Debug</Typography>
+            <pre style={{ backgroundColor: 'white' }}>
+              <code>{JSON.stringify(e, null, 2)}</code>
+            </pre>
+          </Box>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/shared/src/endpoints/v1/public.endpoints.ts
+++ b/shared/src/endpoints/v1/public.endpoints.ts
@@ -1,8 +1,10 @@
 import * as t from 'io-ts';
-import { ContributorPersonalStats } from '../../models/contributor/ContributorPersonalStats';
-import { SearchQuery } from '../../models/http/SearchQuery';
 import { Endpoint } from 'ts-endpoint';
+import { ContributorPersonalStats } from '../../models/contributor/ContributorPersonalStats';
+import { ContributorPersonalSummary } from '../../models/contributor/ContributorPersonalSummary';
 import { CreatorStats } from '../../models/CreatorStats';
+import { PublicKeyParams } from '../../models/http/params/PublicKey';
+import { SearchQuery } from '../../models/http/SearchQuery';
 
 const GetAuthorStatsByVideoId = Endpoint({
   Method: 'GET',
@@ -18,12 +20,23 @@ const GetPersonalStatsByPublicKey = Endpoint({
   getPath: ({ publicKey }) => `/v1/personal/${publicKey}`,
   Input: {
     Query: SearchQuery,
-    Params: t.type({ publicKey: t.string }),
+    Params: PublicKeyParams,
   },
   Output: ContributorPersonalStats,
+});
+
+const GetPersonalSummaryByPublicKey = Endpoint({
+  Method: 'GET',
+  getPath: ({ publicKey }) => `/v1/personal/${publicKey}/summary/json`,
+  Input: {
+    Query: SearchQuery,
+    Params: PublicKeyParams,
+  },
+  Output: ContributorPersonalSummary,
 });
 
 export const endpoints = {
   GetAuthorStatsByVideoId,
   GetPersonalStatsByPublicKey,
+  GetPersonalSummaryByPublicKey,
 };

--- a/shared/src/endpoints/v2/index.ts
+++ b/shared/src/endpoints/v2/index.ts
@@ -4,6 +4,7 @@ import {
   ADVContributionEvent,
   VideoContributionEvent,
 } from '../../models/ContributionEvent';
+import { PublicKeyParams } from '../../models/http/params/PublicKey';
 import { SearchQuery } from '../../models/http/SearchQuery';
 import { GuardoniExperiment, Metadata } from '../../models/Metadata';
 import { ChannelADVStats } from '../../models/stats/ChannelADV';
@@ -58,7 +59,7 @@ const GetPersonalCSV = Endpoint({
   getPath: ({ publicKey, type }) => `/v2/personal/${publicKey}/${type}/csv`,
   Input: {
     Params: t.type({
-      publicKey: t.string,
+      ...PublicKeyParams.props,
       type: t.union([
         t.literal('home'),
         t.literal('video'),
@@ -101,12 +102,12 @@ const GetChannelADVStats = Endpoint({
 
 const GetExperimentList = Endpoint({
   Method: 'GET',
-  getPath: ({ type, key }) => `/v2/guardoni/list/${type}/${key}`,
+  getPath: ({ type, publicKey }) => `/v2/guardoni/list/${type}/${publicKey}`,
   Input: {
     Query: SearchQuery,
     Params: t.type({
       type: t.union([t.literal('comparison'), t.literal('chiaroscuro')]),
-      key: t.string,
+      ...PublicKeyParams.props,
     }),
   },
   Output: t.strict({
@@ -134,7 +135,7 @@ const DeletePersonalContributionByPublicKey = Endpoint({
     `/v2/personal/${publicKey}/selector/id/${selector}`,
   Input: {
     Params: t.type({
-      publicKey: t.string,
+      ...PublicKeyParams.props,
       selector: t.union([t.string, t.undefined]),
     }),
   },

--- a/shared/src/models/contributor/ContributorPersonalSummary.ts
+++ b/shared/src/models/contributor/ContributorPersonalSummary.ts
@@ -1,0 +1,105 @@
+import * as t from 'io-ts';
+
+export const SummaryHTMLMetadata = t.strict(
+  {
+    id: t.string,
+    timelineId: t.string,
+    href: t.string,
+    savingTime: t.string,
+  },
+  'HTMLMetadata'
+);
+
+export type SummaryHTMLMetadata = t.TypeOf<typeof SummaryHTMLMetadata>;
+
+export const SummaryMetadata = t.type(
+  {
+    id: t.string,
+    author: t.type(
+      {
+        link: t.string,
+        name: t.string,
+        username: t.string,
+      },
+      'Author'
+    ),
+    baretext: t.string,
+    description: t.string,
+    hashtags: t.union([t.array(t.string, 'Hashtags'), t.undefined]),
+    metrics: t.type(
+      {
+        liken: t.string,
+        commentsn: t.union([t.string, t.undefined]),
+        sharen: t.string,
+      },
+      'Metrics'
+    ),
+    music: t.union([
+      t.type(
+        {
+          url: t.string,
+          name: t.string,
+        },
+        'Music'
+      ),
+      t.undefined,
+    ]),
+    order: t.number,
+    savingTime: t.string,
+    stitch: t.union([
+      t.type(
+        {
+          name: t.string,
+          user: t.string,
+        },
+        'Stitch'
+      ),
+      t.undefined,
+    ]),
+    timelineId: t.string,
+    type: t.union([t.literal('foryou'), t.literal('home')], 'MetadataType'),
+    relative: t.string,
+  },
+  'Metadata'
+);
+
+export type SummaryMetadata = t.TypeOf<typeof SummaryMetadata>;
+
+export const ContributorPersonalSummary = t.strict(
+  {
+    // supporter: t.strict({
+    //   _id: t.string,
+    //   publicKey: t.string,
+    //   creationTime: t.string,
+    //   p: t.string,
+    //   lastActivity: t.string,
+    //   version: t.string,
+    //   tag: t.strict({
+    //     id: t.string,
+    //     name: t.string,
+    //     accessibility: t.string,
+    //     lastAccess: t.string,
+    //     description: t.string,
+    //     // _id: t.string
+    //   }),
+    //   hereSince: t.string,
+    // }),
+    htmls: t.array(SummaryHTMLMetadata),
+    metadata: t.array(SummaryMetadata),
+    counters: t.strict({
+      metadata: t.number,
+      full: t.number,
+      htmlavail: t.number,
+    }),
+    // request: t.strict({
+    //   amount: t.number,
+    //   skip: t.number,
+    //   when: t.string,
+    // }),
+  },
+  'ContributorPersonalSummary'
+);
+
+export type ContributorPersonalSummary = t.TypeOf<
+  typeof ContributorPersonalSummary
+>;

--- a/shared/src/models/http/params/PublicKey.ts
+++ b/shared/src/models/http/params/PublicKey.ts
@@ -1,0 +1,7 @@
+import * as t from 'io-ts';
+
+export const PublicKeyParams = t.type(
+  { publicKey: t.string },
+  'PublicKeyParams'
+);
+export type PublicKeyParams = t.TypeOf<typeof PublicKeyParams>;


### PR DESCRIPTION
I've defined 2 different queries for tik tok metadata that use the same API `/v1/personal/${publicKey}/summary/json` and extract `htmls` and `metadata` respectively.

This would let @SalvatoreRomano1 use Taboule in tik tok website