### PR TITLE
ci: produce only a 'prelease' in beta flow

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -30,8 +30,7 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # run: yarn release-it --ci --preRelease
         run: |
           git config --global user.email "team@tracking.exposed"
           git config --global user.name "Team - Tracking Exposed"
-          yarn release-it premajor --ci --preReleaseId=beta --github.preRelease=true
+          yarn release-it --ci --preRelease


### PR DESCRIPTION
After releasing the `v2.0.0-beta.0` version we need to change the release command in the `beta` ci flow to avoid producing another "premajor" release on the next merge