### PR TITLE
ci: ycai deploy for different envs

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -34,3 +34,18 @@ jobs:
           git config --global user.email "team@tracking.exposed"
           git config --global user.name "Team - Tracking Exposed"
           yarn release-it --ci --preRelease
+
+      - name: Build Dashboard
+        env:
+          DOTENV_CONFIG_PATH: .env.beta
+        run: yarn ycai build
+
+      - name: Deploy YCAI Dashboard
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: ./YCAI/build/dashboard/
+          remote_path: ~/beta-studio/
+          remote_host: ${{ secrets.YCAI_BETA_DEPLOY_HOST }}
+          remote_user: ${{ secrets.YCAI_BETA_DEPLOY_USER }}
+          remote_key: ${{ secrets.YCAI_BETA_DEPLOY_KEY }}

--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -1,0 +1,46 @@
+name: TRex - Release "daily"
+on:
+  pull_request:
+    branches:
+      - daily
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+          cache-dependency-path: yarn.lock
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Build Dashboard
+        env:
+          DOTENV_CONFIG_PATH: .env.beta
+        run: yarn ycai build
+
+      # - name: Next Release
+      #   run: yarn release-it --preReleaseId=beta --dry-run
+
+      - name: Deploy YCAI Dashboard
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: ./YCAI/build/dashboard/
+          remote_path: ~/staging-studio/
+          remote_host: ${{ secrets.YCAI_DAILY_DEPLOY_HOST }}
+          remote_user: ${{ secrets.YCAI_DEPLOY_USER }}
+          remote_key: ${{ secrets.YCAI_DEPLOY_KEY }}

--- a/.github/workflows/ycai_pull_request.yml
+++ b/.github/workflows/ycai_pull_request.yml
@@ -45,7 +45,19 @@ jobs:
         run: yarn build:ext
 
       - name: Build dashboard
+        env:
+          PUBLIC_URL: https://staging.studio.youchoose.ai
         run: yarn build
 
       - name: Test
         run: yarn test
+
+      - name: Deploy YCAI Dashboard
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: ./YCAI/build/dashboard/
+          remote_path: ~/staging-studio/
+          remote_host: ${{ secrets.YCAI_DAILY_DEPLOY_HOST }}
+          remote_user: ${{ secrets.YCAI_DEPLOY_USER }}
+          remote_key: ${{ secrets.YCAI_DEPLOY_KEY }}

--- a/.github/workflows/ycai_pull_request.yml
+++ b/.github/workflows/ycai_pull_request.yml
@@ -51,13 +51,3 @@ jobs:
 
       - name: Test
         run: yarn test
-
-      - name: Deploy YCAI Dashboard
-        uses: burnett01/rsync-deployments@5.1
-        with:
-          switches: -avzr --delete
-          path: ./YCAI/build/dashboard/
-          remote_path: ~/staging-studio/
-          remote_host: ${{ secrets.YCAI_DAILY_DEPLOY_HOST }}
-          remote_user: ${{ secrets.YCAI_DEPLOY_USER }}
-          remote_key: ${{ secrets.YCAI_DEPLOY_KEY }}

--- a/YCAI/.env.beta
+++ b/YCAI/.env.beta
@@ -1,0 +1,10 @@
+# bundle env
+BUNDLE_ENABLE_NOTIFY=false
+BUNDLE_TARGET=chrome
+
+# app env
+PUBLIC_URL=https://beta.studio.youchoose.ai
+API_URL=https://api.youchoose.ai/api
+WEB_URL=https://youchoose.ai
+DATA_DONATION_FLUSH_INTERVAL=10000
+DEBUG=@yttrex:*


### PR DESCRIPTION
- I've defined a workflow for the CI that deploys the dashboard on `staging.studio.youchoose.ai` when we create a PR against `daily` - once tested will be switched to "push" on daily.