### PR TITLE
test: fix root execution

### DIFF
--- a/.github/workflows/beta_release.yml
+++ b/.github/workflows/beta_release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      - name: Test project
+        run: yarn test
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      - name: Test project
+        run: yarn test
+
       - name: Build Dashboard
         env:
           DOTENV_CONFIG_PATH: .env.beta

--- a/YCAI/jest.config.js
+++ b/YCAI/jest.config.js
@@ -1,28 +1,33 @@
 const { pathsToModuleNameMapper } = require('ts-jest');
+const jestConfigBase = require('../jest.config.base');
 const tsConfig = require('./tsconfig.json');
 
-const moduleNameMapper = pathsToModuleNameMapper(
-  tsConfig.compilerOptions.paths, {
-    prefix: '<rootDir>/src'
-  }
-);
+const tsPaths = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+  prefix: '<rootDir>/src/',
+});
+
+const moduleNameMapper = {
+  ...tsPaths,
+  '\\.(svg|ttf)$': '<rootDir>/__mocks__/fileMock.js',
+  '\\.(css)$': '<rootDir>/__mocks__/styleMock.js',
+};
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest',
+  ...jestConfigBase,
   testEnvironment: 'jsdom',
-  moduleNameMapper: {
-    ...moduleNameMapper,
-    '\\.(svg|ttf)$': '<rootDir>/__mocks__/fileMock.js',
-    '\\.(css)$': '<rootDir>/__mocks__/styleMock.js',
-  },
+  displayName: 'YCAI',
+  moduleNameMapper,
   globals: {
     'ts-jest': {
       // TS reports strange errors with jest,
       // that it doesn't report when running plain tsc...
-      diagnostics: false,
+      diagnostics: true,
       isolatedModules: true,
+      useESM: true,
+      tsconfig: '<rootDir>/tsconfig.json',
     },
   },
-  setupFilesAfterEnv: ['./jest.setup.js'],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  collectCoverageFrom: ['<rootDir>src/**'],
 };

--- a/YCAI/package.json
+++ b/YCAI/package.json
@@ -61,7 +61,7 @@
     "semantic-release": "^19.0.2",
     "style-loader": "^3.3.1",
     "svgdom": "^0.1.10",
-    "ts-jest": "^27.1.2",
+    "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,40 +1,41 @@
-const tsConfig = require("./tsconfig.json");
+const jestBaseConfig = require('../jest.config.base');
+const tsConfig = require('./tsconfig.json');
 // jest.config.js
-const { pathsToModuleNameMapper } = require("ts-jest");
-const { jsWithTsESM } = require("ts-jest/presets");
+const { pathsToModuleNameMapper } = require('ts-jest');
 
-const moduleNameMapper = pathsToModuleNameMapper(
-  tsConfig.compilerOptions.paths,
-  {
-    prefix: "<rootDir>",
-  }
-);
+const paths = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+  prefix: '<rootDir>',
+});
+
+const moduleNameMapper = {
+  ...paths,
+  ...jestBaseConfig.moduleNameMapper,
+};
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  roots: ["./", "../packages/shared"],
-  projects: ['./', '../packages/shared'],
+  ...jestBaseConfig,
+  displayName: 'backend',
   moduleNameMapper,
   globals: {
-    "ts-jest": {
+    'ts-jest': {
       // TS reports strange errors with jest,
       // that it doesn't report when running plain tsc...
       diagnostics: false,
       isolatedModules: true,
-      useESM: true
+      useESM: true,
+      tsconfig: '<rootDir>/tsconfig.json',
     },
   },
-  transform: {
-    ...jsWithTsESM.transform,
-    '\\.js$': 'ts-jest'
-  },
-  clearMocks: true,
   testTimeout: 10000,
-  setupFilesAfterEnv: ["./jest.setup.js"],
-  coverageProvider:"v8",
-  collectCoverageFrom: ["./bin/**", "./lib/**", "./routes/**", "./parsers/**"],
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  coverageProvider: 'v8',
+  collectCoverageFrom: [
+    '<rootDir>/bin/**',
+    '<rootDir>/lib/**',
+    '<rootDir>/routes/**',
+    '<rootDir>/parsers/**',
+  ],
   coverageThreshold: {
     global: {
       branches: 30,
@@ -43,5 +44,4 @@ module.exports = {
       statements: 60,
     },
   },
-  coveragePathIgnorePatterns: ["node_modules"],
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -65,7 +65,7 @@
     "jest": "^27.4.7",
     "prettier": "^2.5.1",
     "supertest": "^6.1.6",
-    "ts-jest": "^27.1.2",
+    "ts-jest": "^27.1.3",
     "tsconfig-paths": "^3.12.0",
     "typescript": "^4.5.4"
   }

--- a/guardoni/global-setup.js
+++ b/guardoni/global-setup.js
@@ -1,9 +1,9 @@
 // global-setup.js
 const { setup: setupDevServer } = require('jest-dev-server');
-const { dirname } = require('path');
+const { basename } = require('path');
 
 module.exports = async function globalSetup() {
-  const currentDir = dirname(process.cwd());
+  const currentDir = basename(process.cwd());
   const currentDirCommand = currentDir === 'guardoni' ? '../' : './';
   await setupDevServer({
     command: `cd ${currentDirCommand} && yarn backend watch`,

--- a/guardoni/global-setup.js
+++ b/guardoni/global-setup.js
@@ -1,11 +1,15 @@
 // global-setup.js
 const { setup: setupDevServer } = require('jest-dev-server');
+const { dirname } = require('path');
 
 module.exports = async function globalSetup() {
+  const currentDir = dirname(process.cwd());
+  const currentDirCommand = currentDir === 'guardoni' ? '../' : './';
   await setupDevServer({
-    command: `cd ../ && yarn backend watch`,
+    command: `cd ${currentDirCommand} && yarn backend watch`,
     launchTimeout: 50000,
     port: 9000,
   });
+
   // Your global setup
 };

--- a/guardoni/jest.config.js
+++ b/guardoni/jest.config.js
@@ -1,50 +1,40 @@
+const jestBaseConfig = require('../jest.config.base');
 const tsConfig = require('./tsconfig.json');
-// jest.config.js
 const { pathsToModuleNameMapper } = require('ts-jest');
-const { jsWithTsESM } = require('ts-jest/presets');
 
-const moduleNameMapper = pathsToModuleNameMapper(
-  tsConfig.compilerOptions.paths,
-  {
-    prefix: '<rootDir>/src',
-  }
-);
+const tsPaths = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
+  prefix: '<rootDir>/src/',
+});
+
+const moduleNameMapper = {
+  ...tsPaths,
+};
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['./', '../packages/shared'],
-  projects: ['./', '../packages/shared'],
+  ...jestBaseConfig,
+  rootDir: __dirname,
+  displayName: 'guardoni',
   moduleNameMapper,
-  modulePathIgnorePatterns: ['profiles', 'build'],
+  modulePathIgnorePatterns: [
+    ...jestBaseConfig.modulePathIgnorePatterns,
+    'profiles',
+    'build',
+  ],
   globals: {
     'ts-jest': {
       // TS reports strange errors with jest,
       // that it doesn't report when running plain tsc...
-      diagnostics: false,
+      diagnostics: true,
       isolatedModules: true,
       useESM: true,
+      tsconfig: '<rootDir>/tsconfig.json',
     },
   },
-  transform: {
-    ...jsWithTsESM.transform,
-    '\\.js$': 'ts-jest',
-  },
-  clearMocks: true,
   testTimeout: 10000,
-  setupFilesAfterEnv: ['./jest.setup.js'],
-  globalSetup: './global-setup.js',
-  globalTeardown: './global-teardown.js',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  globalSetup: '<rootDir>/global-setup.js',
+  globalTeardown: '<rootDir>/global-teardown.js',
   coverageProvider: 'v8',
-  collectCoverageFrom: ['./src/**'],
-  coverageThreshold: {
-    global: {
-      branches: 30,
-      functions: 60,
-      lines: 60,
-      statements: 60,
-    },
-  },
-  coveragePathIgnorePatterns: ['node_modules'],
+  collectCoverageFrom: ['<rootDir>/src/**'],
 };

--- a/guardoni/package.json
+++ b/guardoni/package.json
@@ -91,7 +91,7 @@
     "prettier": "^2.5.1",
     "rpmbuild": "^0.0.23",
     "style-loader": "^3.3.1",
-    "ts-jest": "^27.1.2",
+    "ts-jest": "^27.1.3",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.4",
     "utf-8-validate": "^5.0.7",

--- a/guardoni/tsconfig.json
+++ b/guardoni/tsconfig.json
@@ -3,21 +3,22 @@
   "compilerOptions": {
     "allowJs": true,
     "strict": true,
-    "noEmit": true,
+    "noEmit": false,
     "target": "ES3",
     "lib": ["ESNext", "DOM"],
     "jsx": "react",
-    "rootDir": "./",
+    "outDir": "./build/ts",
     "baseUrl": "./src",
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    "sourceMap": true,
     "typeRoots": ["../node_modules/@types", "node_modules/@types"],
     "paths": {
       "@shared/*": ["../../packages/shared/src/*"]
     }
   },
+  "include": ["./src"],
+  "exclude": ["node_modules", "build", "dist"],
   "watchOptions": {
     "watchFile": "useFsEvents",
     "watchDirectory": "useFsEvents",

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -1,0 +1,39 @@
+const tsJestPresets = require('ts-jest/presets');
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  ...tsJestPresets.jsWithTsESM,
+  preset: 'ts-jest',
+  verbose: true,
+  testEnvironment: 'node',
+  globals: {
+    'ts-jest': {
+      // TS reports strange errors with jest,
+      // that it doesn't report when running plain tsc...
+      diagnostics: true,
+      isolatedModules: true,
+      useESM: true,
+      tsconfig: '<rootDir>/tsconfig.json',
+    },
+  },
+  moduleNameMapper: {
+    '^@shared/(.*)$': '<rootDir>/../packages/shared/src/$1',
+    '^@taboule/(.*)$': '<rootDir>/../packages/taboule/src/$1',
+  },
+  testMatch: [
+    '**/__tests__/**/*.[jt]s?(x)',
+    '**/?(*.)+(spec|test|e2e).[tj]s?(x)',
+  ],
+  moduleDirectories: ['node_modules'],
+  modulePathIgnorePatterns: ['__mocks__'],
+  clearMocks: true,
+  coverageThreshold: {
+    global: {
+      branches: 30,
+      functions: 60,
+      lines: 60,
+      statements: 60,
+    },
+  },
+  coveragePathIgnorePatterns: ['node_modules'],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,38 +1,7 @@
-const { pathsToModuleNameMapper } = require('ts-jest');
-
-const moduleNameMapper = pathsToModuleNameMapper(
-  {
-    '@shared/*': ['./shared/src/*'],
-  },
-  {
-    prefix: '<rootDir>',
-  }
-);
+const jestBaseConfig = require('./jest.config.base');
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['./', './backend', './guardoni', './YCAI'],
-  projects: ['./backend', './guardoni', './YCAI'],
-  modulePathIgnorePatterns: ['__mocks__'],
-  globals: {
-    'ts-jest': {
-      // TS reports strange errors with jest,
-      // that it doesn't report when running plain tsc...
-      diagnostics: false,
-      isolatedModules: true,
-    },
-  },
-  moduleNameMapper,
-  clearMocks: true,
-  coverageThreshold: {
-    global: {
-      branches: 30,
-      functions: 60,
-      lines: 60,
-      statements: 60,
-    },
-  },
-  coveragePathIgnorePatterns: ['node_modules'],
+  ...jestBaseConfig,
+  projects: ['<rootDir>/backend', '<rootDir>/guardoni', '<rootDir>/YCAI'],
 };

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "prettier": "^2.5.1",
     "release-it": "^14.12.4",
     "release-it-yarn-workspaces": "^2.0.1",
-    "ts-jest": "^27.1.2",
+    "ts-jest": "^27.1.3",
     "typescript": "^4.5.4",
     "webpack": "^5.67.0"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -49,7 +49,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.2.0",
     "eslint-plugin-react": "^7.28.0",
-    "fast-check": "^2.20.0",
+    "fast-check": "^2.21.0",
     "fast-check-io-ts": "^0.5.0",
     "filemanager-webpack-plugin": "^6.1.7",
     "mini-css-extract-plugin": "^2.4.6",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "noEmit": false,
     "composite": true,
     "lib": ["ESNext", "DOM"],
     "typeRoots": ["../../node_modules/@types", "./node_modules/@types"],

--- a/services/tktrex/shared/package.json
+++ b/services/tktrex/shared/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-promise": "^5.2.0",
     "eslint-plugin-react": "^7.28.0",
     "jest": "^27.4.7",
-    "ts-jest": "^27.1.2",
+    "ts-jest": "^27.1.3",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
     "yargs": "^17.3.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,12 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "strict": true,
+    "noEmit": true,
     "strictNullChecks": true,
     "allowUnusedLabels": false,
     "isolatedModules": true,
+    "esModuleInterop": true,
     "rootDir": "./"
   },
   "exclude": ["**/node_modules/*", "**/build/*"]

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": true,
+    "strictNullChecks": true,
+    "allowUnusedLabels": false,
+    "isolatedModules": true,
+    "rootDir": "./",
+    "outDir": "./build"
+  },
+  "include": ["backend/src/**", "guardoni/src/**", "YCAI/src/**"],
+  "exclude": ["node_modules", "build", "lib"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1914,7 +1914,7 @@ __metadata:
     eslint-plugin-node: ^11.1.0
     eslint-plugin-promise: ^5.2.0
     eslint-plugin-react: ^7.28.0
-    fast-check: ^2.20.0
+    fast-check: ^2.21.0
     fast-check-io-ts: ^0.5.0
     filemanager-webpack-plugin: ^6.1.7
     fp-ts: ^2.11.8
@@ -2060,7 +2060,7 @@ __metadata:
     svgdom: ^0.1.10
     swagger-ui: ^4.1.3
     ts-endpoint: ^2.0.0
-    ts-jest: ^27.1.2
+    ts-jest: ^27.1.3
     ts-loader: ^9.2.6
     ts-node: ^10.4.0
     tweetnacl: ^1.0.3
@@ -9831,7 +9831,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-check@npm:^2.20.0":
+"fast-check@npm:^2.21.0":
   version: 2.21.0
   resolution: "fast-check@npm:2.21.0"
   dependencies:
@@ -11234,7 +11234,7 @@ __metadata:
     react-dom: ^17.0.2
     rpmbuild: ^0.0.23
     style-loader: ^3.3.1
-    ts-jest: ^27.1.2
+    ts-jest: ^27.1.3
     ts-loader: ^9.2.6
     typescript: ^4.5.4
     utf-8-validate: ^5.0.7
@@ -19236,7 +19236,7 @@ __metadata:
     prettier: ^2.5.1
     release-it: ^14.12.4
     release-it-yarn-workspaces: ^2.0.1
-    ts-jest: ^27.1.2
+    ts-jest: ^27.1.3
     typescript: ^4.5.4
     webpack: ^5.67.0
   languageName: unknown
@@ -21232,7 +21232,7 @@ __metadata:
     jest: ^27.4.7
     linkedom: ^0.13.0
     mongodb: ^4.3.1
-    ts-jest: ^27.1.2
+    ts-jest: ^27.1.3
     ts-node: ^10.4.0
     typescript: ^4.5.4
     yargs: ^17.3.1
@@ -21522,7 +21522,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^27.1.2":
+"ts-jest@npm:^27.1.3":
   version: 27.1.3
   resolution: "ts-jest@npm:27.1.3"
   dependencies:
@@ -23441,7 +23441,7 @@ __metadata:
     supertest: ^6.1.6
     ts-endpoint: ^2.0.0
     ts-io-error: ^2.0.0
-    ts-jest: ^27.1.2
+    ts-jest: ^27.1.3
     ts-node: ^10.4.0
     ts-node-dev: ^1.1.8
     tsconfig-paths: ^3.12.0


### PR DESCRIPTION
This PR fixes the script `yarn test` from the project's root.
Basically the `global-setup.ts` in `guardoni` was throwing because of a too opinionated server start command.
