### PR TITLE
feat: delete recommendation from library

### DIFF
--- a/YCAI/src/components/dashboard/lab/RecommendationCard.tsx
+++ b/YCAI/src/components/dashboard/lab/RecommendationCard.tsx
@@ -21,7 +21,7 @@ import { makeStyles } from '@material-ui/styles';
 import {
   titleMaxLength,
   descriptionMaxLength,
-  Recommendation
+  Recommendation,
 } from '@shared/models/Recommendation';
 import { YCAITheme } from '../../../theme';
 import CharLimitedTypography from '../../common/CharLimitedTypography';
@@ -33,7 +33,7 @@ import { getHostFromURL } from '../../../utils/location.utils';
 interface RecommendationCardProps {
   videoId: string;
   data: Recommendation;
-  onDeleteClick: () => void;
+  onDeleteClick: (r: Recommendation) => void;
   onMoveUpClick: (() => void) | false;
   onMoveDownClick: (() => void) | false;
 }
@@ -54,7 +54,7 @@ const useStyles = makeStyles<YCAITheme>((theme) => ({
       height: cardHeight,
       width: '100%',
       objectFit: 'cover',
-    }
+    },
   },
   body: {
     height: cardHeight,
@@ -99,19 +99,19 @@ const useStyles = makeStyles<YCAITheme>((theme) => ({
     fontSize: '0.8rem',
     '& svg': {
       marginTop: -1,
-      marginRight: theme.spacing(.5),
+      marginRight: theme.spacing(0.5),
     },
   },
   clamped: {
     display: '-webkit-box',
     boxOrient: 'vertical',
     wordBreak: 'keep-all',
-    overflow: 'hidden'
+    overflow: 'hidden',
   },
   description: {
     color: theme.palette.grey[500],
     lineClamp: 3,
-  }
+  },
 }));
 
 export const RecommendationCard: React.FC<RecommendationCardProps> = ({
@@ -132,22 +132,12 @@ export const RecommendationCard: React.FC<RecommendationCardProps> = ({
       <Grid container spacing={1}>
         <Grid item xs={5}>
           <div className={classes.imageContainer}>
-            <Image
-              src={data.image}
-              title={data.title}
-            />
+            <Image src={data.image} title={data.title} />
           </div>
         </Grid>
 
-        <Grid
-          item xs={6}
-          className={classes.body}
-        >
-          <Box
-            className={classes.right}
-            display="flex"
-            flexDirection="column"
-          >
+        <Grid item xs={6} className={classes.body}>
+          <Box className={classes.right} display="flex" flexDirection="column">
             <CharLimitedTypography
               className={`${classes.title} ${classes.clamped}`}
               color="textSecondary"
@@ -158,10 +148,12 @@ export const RecommendationCard: React.FC<RecommendationCardProps> = ({
             >
               {data.title}
             </CharLimitedTypography>
-            {isExternal && (<Typography className={classes.source}>
-              <LinkIcon />
-              {getHostFromURL(data.url)}
-            </Typography>)}
+            {isExternal && (
+              <Typography className={classes.source}>
+                <LinkIcon />
+                {getHostFromURL(data.url)}
+              </Typography>
+            )}
 
             <Box flexGrow={1} display="flex" alignItems="center">
               <CharLimitedTypography
@@ -176,7 +168,7 @@ export const RecommendationCard: React.FC<RecommendationCardProps> = ({
             <Box>
               <Button
                 className={classes.button}
-                onClick={onDeleteClick}
+                onClick={() => onDeleteClick(data)}
                 size="small"
                 variant="text"
               >
@@ -194,34 +186,30 @@ export const RecommendationCard: React.FC<RecommendationCardProps> = ({
           </Box>
         </Grid>
 
-        <Grid
-          item
-          xs={1}
-          className={classes.iconsContainer}
-        >
+        <Grid item xs={1} className={classes.iconsContainer}>
           <IconButton
-              aria-label={t('actions:move_recommendation_up')}
-              color="primary"
-              className={classes.arrowButton}
-              disabled={onMoveUpClick === false}
-              // there seems to be an eslint bug,
-              // there is no way to get rid of all the warnings whatever I do
-              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-              onClick={onMoveUpClick || undefined}
-              size="small"
-              >
-              <ArrowUpwardIcon />
+            aria-label={t('actions:move_recommendation_up')}
+            color="primary"
+            className={classes.arrowButton}
+            disabled={onMoveUpClick === false}
+            // there seems to be an eslint bug,
+            // there is no way to get rid of all the warnings whatever I do
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+            onClick={onMoveUpClick || undefined}
+            size="small"
+          >
+            <ArrowUpwardIcon />
           </IconButton>
           <IconButton
-              aria-label={t('actions:move_recommendation_down')}
-              color="primary"
-              className={classes.arrowButton}
-              disabled={onMoveDownClick === false}
-              // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-              onClick={onMoveDownClick || undefined}
-              size="small"
-              >
-              <ArrowDownwardIcon />
+            aria-label={t('actions:move_recommendation_down')}
+            color="primary"
+            className={classes.arrowButton}
+            disabled={onMoveDownClick === false}
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+            onClick={onMoveDownClick || undefined}
+            size="small"
+          >
+            <ArrowDownwardIcon />
           </IconButton>
         </Grid>
       </Grid>

--- a/YCAI/src/components/dashboard/lab/RecommendationsLibrary/RecommendationsList.tsx
+++ b/YCAI/src/components/dashboard/lab/RecommendationsLibrary/RecommendationsList.tsx
@@ -6,10 +6,12 @@ import { RecommendationCard } from '../RecommendationCard';
 
 interface RecommendationListProps {
   recommendations: Recommendation[];
+  onDeleteClick: (r: Recommendation) => void;
 }
 
 const RecommendationList: React.FC<RecommendationListProps> = ({
   recommendations,
+  onDeleteClick,
 }) => {
   const { t } = useTranslation();
 
@@ -24,7 +26,7 @@ const RecommendationList: React.FC<RecommendationListProps> = ({
             key={r.urlId}
             data={r}
             videoId={''}
-            onDeleteClick={() => {}}
+            onDeleteClick={onDeleteClick}
             onMoveDownClick={() => {}}
             onMoveUpClick={() => {}}
           />

--- a/YCAI/src/components/dashboard/lab/RecommendationsLibrary/index.tsx
+++ b/YCAI/src/components/dashboard/lab/RecommendationsLibrary/index.tsx
@@ -1,11 +1,15 @@
 import { Box, Grid } from '@material-ui/core';
 import { ErrorBox } from '@shared/components/Error/ErrorBox';
+import { Recommendation } from '@shared/models/Recommendation';
 import * as QR from 'avenger/lib/QueryResult';
 import { WithQueries } from 'avenger/lib/react';
-import { LazyFullSizeLoader } from '../../../common/FullSizeLoader';
 import * as React from 'react';
-import { addRecommendation } from '../../../../state/dashboard/creator.commands';
+import {
+  addRecommendation,
+  deleteRecommendation,
+} from '../../../../state/dashboard/creator.commands';
 import * as queries from '../../../../state/dashboard/creator.queries';
+import { LazyFullSizeLoader } from '../../../common/FullSizeLoader';
 import AddRecommendationBox from '../AddRecommendationBox';
 import RecommendationList from './RecommendationsList';
 
@@ -13,6 +17,12 @@ const RecommendationsLibrary: React.FC = () => {
   const handleRecommendationAdd = React.useCallback((url: string) => {
     void addRecommendation({
       url,
+    })();
+  }, []);
+
+  const handleRecommendationDelete = React.useCallback((r: Recommendation) => {
+    void deleteRecommendation({
+      urlId: r.urlId,
     })();
   }, []);
 
@@ -25,7 +35,10 @@ const RecommendationsLibrary: React.FC = () => {
             <Grid item md={6}>
               <AddRecommendationBox onAddClick={handleRecommendationAdd} />
               <Box>
-                <RecommendationList recommendations={recommendations} />
+                <RecommendationList
+                  recommendations={recommendations}
+                  onDeleteClick={handleRecommendationDelete}
+                />
               </Box>
             </Grid>
           </Grid>

--- a/YCAI/src/state/dashboard/creator.commands.ts
+++ b/YCAI/src/state/dashboard/creator.commands.ts
@@ -1,14 +1,14 @@
+import * as sharedConst from '@shared/constants';
+import { AppError } from '@shared/errors/AppError';
+import { AuthResponse } from '@shared/models/Auth';
+import { ContentCreator } from '@shared/models/ContentCreator';
+import { PartialRecommendation } from '@shared/models/Recommendation';
+import { setItem } from '@shared/providers/localStorage.provider';
 import { command } from 'avenger';
 import { sequenceS } from 'fp-ts/lib/Apply';
 import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
-import { AppError } from '@shared/errors/AppError';
-import * as sharedConst from '@shared/constants';
 import { API } from '../../api';
-import { setItem } from '@shared/providers/localStorage.provider';
-import { AuthResponse } from '@shared/models/Auth';
-import { ContentCreator } from '@shared/models/ContentCreator';
-import { PartialRecommendation } from '@shared/models/Recommendation';
 import {
   auth,
   ccRelatedUsers,
@@ -173,6 +173,24 @@ export const patchRecommendation = command(
       })
     ),
   { videoRecommendations }
+);
+
+export const deleteRecommendation = command(
+  ({ urlId }: { urlId: string }) =>
+    pipe(
+      profile.run(),
+      TE.chain((p) => {
+        return API.v3.Creator.DeleteRecommendation({
+          Headers: {
+            'x-authorization': p.accessToken,
+          },
+          Params: { urlId },
+        });
+      })
+    ),
+  {
+    creatorRecommendations,
+  }
 );
 
 export const updateAuth = command(

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-misused-promises */
 import { makeBackend } from '@shared/backend';
+import { RouteContext } from '@shared/backend/types';
 import { GetLogger } from '@shared/logger';
 import bodyParser from 'body-parser';
 import cors from 'cors';
@@ -8,6 +9,7 @@ import * as _ from 'lodash';
 import { MongoClient } from 'mongodb';
 import { apiList } from '../lib/api';
 import mongo3 from '../lib/mongo3';
+import { DeleteRecommendationRoute } from '../routes/youchoose/deleteRecommendation.route';
 
 const logger = GetLogger('api');
 const logAPICount = { requests: {}, responses: {}, errors: {} };
@@ -109,11 +111,16 @@ export const makeApp = async (
   // get a router instance from express
   const router = express.Router();
 
-  const db = {
-    ...mongo3,
-    mongo: ctx.mongo,
+  const routeCtx: RouteContext = {
+    logger,
+    db: {
+      ...mongo3,
+      mongo: ctx.mongo,
+    },
   };
-  const apiRouter = makeBackend({ db, logger }, express.Router());
+  const apiRouter = makeBackend(routeCtx, express.Router());
+
+  DeleteRecommendationRoute(apiRouter, routeCtx);
 
   /* this API is v0 as it is platform neutral. it might be shared among
    * all the trex backends, and should return info on system health, echo OK

--- a/backend/routes/__tests__/youchoose.e2e.ts
+++ b/backend/routes/__tests__/youchoose.e2e.ts
@@ -1,27 +1,27 @@
 /* eslint-disable import/first */
 // mock curly module
-jest.mock("../../lib/curly");
-jest.mock("fetch-opengraph");
+jest.mock('../../lib/curly');
+jest.mock('fetch-opengraph');
 
 // import test utils
-import { Test, GetTest } from "../../tests/Test";
-import * as t from "io-ts";
-import * as E from "fp-ts/lib/Either";
+import { Test, GetTest } from '../../tests/Test';
+import * as t from 'io-ts';
+import * as E from 'fp-ts/lib/Either';
 // import mocked curly from source
-import * as curly from "../../lib/curly";
-import { ContentCreator } from "@shared/models/ContentCreator";
-import { fc } from "@shared/test";
-import { ContentCreatorArb } from "@shared/arbitraries/ContentCreator.arb";
-import { VideoArb } from "@shared/arbitraries/Video.arb";
-import { Video } from "@shared/models/Video";
-import { v4 as uuid } from "uuid";
-import fetchOpenGraph from "fetch-opengraph";
-import { Recommendation } from "@shared/models/Recommendation";
+import * as curly from '../../lib/curly';
+import { ContentCreator } from '@shared/models/ContentCreator';
+import { fc } from '@shared/test';
+import { ContentCreatorArb } from '@shared/arbitraries/ContentCreator.arb';
+import { VideoArb } from '@shared/arbitraries/Video.arb';
+import { Video } from '@shared/models/Video';
+import { v4 as uuid } from 'uuid';
+import fetchOpenGraph from 'fetch-opengraph';
+import { Recommendation } from '@shared/models/Recommendation';
 
 const curlyMock = curly as jest.Mocked<typeof curly>;
 const fetchOpenGraphMock = fetchOpenGraph as jest.Mocked<typeof fetchOpenGraph>;
 
-describe("The YouChoose API", () => {
+describe('The YouChoose API', () => {
   const channelId = uuid();
   let test: Test,
     verificationToken: string,
@@ -37,28 +37,28 @@ describe("The YouChoose API", () => {
     await test.mongo.close();
   });
 
-  describe("Register a Content Creator", () => {
-    it("fails using channelId", async () => {
+  describe('Register a Content Creator', () => {
+    it('fails using channelId', async () => {
       const registrationError = {
         error: true,
-        message: "Channel id not found",
+        message: 'Channel id not found',
       };
       curlyMock.verifyChannel.mockResolvedValueOnce(registrationError);
 
       const { body } = await test.app
         .post(`/api/v3/creator/${channelId}/register`)
-        .send({ type: "channel" })
+        .send({ type: 'channel' })
         .expect(500);
 
       expect(body).toEqual(registrationError);
     });
 
-    it("succeeds using channelId", async () => {
+    it('succeeds using channelId', async () => {
       curlyMock.verifyChannel.mockResolvedValueOnce(true);
 
       const { body } = await test.app
         .post(`/api/v3/creator/${channelId}/register`)
-        .send({ type: "channel" })
+        .send({ type: 'channel' })
         .expect(200);
 
       expect(body.verified).toBe(false);
@@ -67,30 +67,30 @@ describe("The YouChoose API", () => {
     });
   });
 
-  describe("Verify Content Creator", () => {
-    it("fails to verify Content Creator for wrong code", async () => {
+  describe('Verify Content Creator', () => {
+    it('fails to verify Content Creator for wrong code', async () => {
       const pageData = {
         ...fc.sample(ContentCreatorArb, 1)[0],
         channelId,
-        code: "fake-code",
+        code: 'fake-code',
       };
       curlyMock.tokenFetch.mockResolvedValueOnce(pageData);
       const { body } = await test.app.post(
         `/api/v3/creator/${channelId}/verify`
       );
 
-      expect(body).toEqual({ error: true, message: "code not found!" });
+      expect(body).toEqual({ error: true, message: 'code not found!' });
     });
 
-    it("fails to verify Content Creator for channelId not found", async () => {
+    it('fails to verify Content Creator for channelId not found', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/${uuid()}/verify`)
         .expect(500);
 
-      expect(body).toEqual({ error: true, message: "token not found" });
+      expect(body).toEqual({ error: true, message: 'token not found' });
     });
 
-    it("verify Content creator", async () => {
+    it('verify Content creator', async () => {
       const { registeredOn, accessToken, ...cc } = fc.sample(
         ContentCreatorArb,
         1
@@ -113,32 +113,32 @@ describe("The YouChoose API", () => {
         contentCreatorData
       );
       expect(new Date(body.registeredOn)).toBeInstanceOf(Date);
-      expect(typeof body.accessToken).toEqual("string");
+      expect(typeof body.accessToken).toEqual('string');
       contentCreator = body;
     });
   });
 
-  describe("Get Content Creator", () => {
-    it("fails get by access token", async () => {
+  describe('Get Content Creator', () => {
+    it('fails get by access token', async () => {
       await test.app
         .get(`/api/v3/creator/me`)
-        .send({ type: "channel" })
-        .set("X-Authorization", "wrong-token")
+        .send({ type: 'channel' })
+        .set('X-Authorization', 'wrong-token')
         .expect(500);
     });
 
-    it("succeeds with access token", async () => {
+    it('succeeds with access token', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/me`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(contentCreator).toMatchObject(body);
     });
   });
 
-  describe("Pull Content Creator videos", () => {
-    it("fails for missing header", async () => {
+  describe('Pull Content Creator videos', () => {
+    it('fails for missing header', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/videos/repull`)
         .expect(500);
@@ -146,18 +146,18 @@ describe("The YouChoose API", () => {
       expect(body).toMatchObject({ error: true });
     });
 
-    it("succeeds with access token", async () => {
+    it('succeeds with access token', async () => {
       const newVideoData = fc.sample(VideoArb, 1).map((v) => ({
         ...v,
         urlId: v.videoId,
-        description: "description-is-required",
+        description: 'description-is-required',
         recommendations: [],
       }));
       curlyMock.recentVideoFetch.mockResolvedValueOnce(newVideoData);
 
       const { body } = await test.app
         .post(`/api/v3/creator/videos/repull`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(body).toMatchObject(newVideoData);
@@ -166,41 +166,41 @@ describe("The YouChoose API", () => {
     });
   });
 
-  describe("Get Content Creator videos", () => {
-    it("fails for missing header", async () => {
+  describe('Get Content Creator videos', () => {
+    it('fails for missing header', async () => {
       const { body } = await test.app.get(`/api/v3/creator/videos`).expect(500);
 
       expect(body).toMatchObject({ error: true });
     });
 
-    it("succeeds with access token", async () => {
+    it('succeeds with access token', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/videos`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(body.length).toBe(1);
     });
 
-    it("succeeds by access token", async () => {
+    it('succeeds by access token', async () => {
       const newVideoData = fc.sample(VideoArb, 1).map((v) => ({
         ...v,
         urlId: v.videoId,
-        description: "always-present",
+        description: 'always-present',
         recommendations: [],
       }));
       curlyMock.recentVideoFetch.mockResolvedValueOnce(newVideoData);
 
       const { body } = await test.app
         .post(`/api/v3/creator/videos/repull`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(newVideoData).toMatchObject(body);
 
       const getVideosResponse = await test.app
         .get(`/api/v3/creator/videos`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(videos.concat(body)).toMatchObject(getVideosResponse.body);
@@ -209,8 +209,8 @@ describe("The YouChoose API", () => {
     });
   });
 
-  describe("Get Content Creator video", () => {
-    it("fails for missing token", async () => {
+  describe('Get Content Creator video', () => {
+    it('fails for missing token', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/videos/${videos[0].videoId}`)
         .expect(500);
@@ -218,25 +218,25 @@ describe("The YouChoose API", () => {
       expect(body).toMatchObject({ error: true });
     });
 
-    it("fails for missing id", async () => {
+    it('fails for missing id', async () => {
       await test.app
         .get(`/api/v3/creator/videos/not-existing-video-id`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(500);
     });
 
-    it("succeeds by videoId", async () => {
+    it('succeeds by videoId', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/videos/${videos[0].videoId}`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(body).toMatchObject(videos[0]);
     });
   });
 
-  describe("Update Content Creator video recommendations", () => {
-    it("fails for missing authentication", async () => {
+  describe('Update Content Creator video recommendations', () => {
+    it('fails for missing authentication', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/ogp`)
         .send({ videoId: videos[0].videoId, url: `http://fake-url/${uuid()}` })
@@ -245,7 +245,7 @@ describe("The YouChoose API", () => {
       expect(body).toMatchObject({ error: true });
     });
 
-    it("succeeds when the url is already present in db", async () => {
+    it('succeeds when the url is already present in db', async () => {
       const urlId = uuid();
       const urlOpenGraph = {
         url: `http://fake.url/${urlId}`,
@@ -259,20 +259,20 @@ describe("The YouChoose API", () => {
       };
       await test.app
         .post(`/api/v3/creator/ogp`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send(recommendationURL)
         .expect(200);
 
       const { body } = await test.app
         .post(`/api/v3/creator/ogp`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send(recommendationURL)
         .expect(200);
 
       expect(body).toMatchObject(recommendationURL);
     });
 
-    it("succeeds with well formed url", async () => {
+    it('succeeds with well formed url', async () => {
       const urlId = uuid();
       const urlOpenGraph = {
         url: `http://fake.url/${urlId}`,
@@ -286,7 +286,7 @@ describe("The YouChoose API", () => {
       };
       const { body } = await test.app
         .post(`/api/v3/creator/ogp`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send(recommendationURL)
         .expect(200);
 
@@ -296,8 +296,8 @@ describe("The YouChoose API", () => {
     });
   });
 
-  describe("Get content Creator recommendations", () => {
-    it("fails for missing header", async () => {
+  describe('Get content Creator recommendations', () => {
+    it('fails for missing header', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/recommendations`)
         .expect(500);
@@ -305,18 +305,18 @@ describe("The YouChoose API", () => {
       expect(body).toMatchObject({ error: true });
     });
 
-    it("succeeds with authentication", async () => {
+    it('succeeds with authentication', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/recommendations`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .expect(200);
 
       expect(E.isRight(t.array(Recommendation).decode(body))).toBe(true);
     });
   });
 
-  describe("Add recommendation to Content Creator videos", () => {
-    it("fails for missing header", async () => {
+  describe('Add recommendation to Content Creator videos', () => {
+    it('fails for missing header', async () => {
       const recommendationURLIds = recommendations.map((r) => r.urlId);
       const { body } = await test.app
         .post(`/api/v3/creator/updateVideo`)
@@ -329,10 +329,10 @@ describe("The YouChoose API", () => {
       expect(body).toMatchObject({ error: true });
     });
 
-    it("fails for missing videoId", async () => {
+    it('fails for missing videoId', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/updateVideo`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send({
           recommendations: [],
         })
@@ -343,10 +343,10 @@ describe("The YouChoose API", () => {
       });
     });
 
-    it("fails for missing recommendations", async () => {
+    it('fails for missing recommendations', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/updateVideo`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send({
           videoId: videos[0].videoId,
         })
@@ -357,12 +357,12 @@ describe("The YouChoose API", () => {
       });
     });
 
-    it("fails for wrong recommendations ids", async () => {
+    it('fails for wrong recommendations ids', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/updateVideo`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send({
-          recommendations: ["fake-id"],
+          recommendations: ['fake-id'],
         })
         .expect(500);
 
@@ -371,11 +371,11 @@ describe("The YouChoose API", () => {
       });
     });
 
-    it("succeeds with new recommendations", async () => {
+    it('succeeds with new recommendations', async () => {
       const recommendationURLIds = recommendations.map((r) => r.urlId);
       const { body } = await test.app
         .post(`/api/v3/creator/updateVideo`)
-        .set("X-Authorization", contentCreator.accessToken as any)
+        .set('X-Authorization', contentCreator.accessToken as any)
         .send({
           videoId: videos[0].videoId,
           recommendations: recommendationURLIds,
@@ -386,6 +386,30 @@ describe("The YouChoose API", () => {
         ...videos[0],
         recommendations: recommendationURLIds,
       });
+    });
+  });
+
+  describe('Delete recommendation from Content Creator library', () => {
+    it('fails for missing header', async () => {
+      await test.app
+        .delete(`/api/v3/creator/recommendations/${recommendations[0].urlId}`)
+        .expect(401);
+    });
+
+    it('fails when url is wrong', async () => {
+      await test.app
+        .delete(`/api/v3/creator/recommendations/wrong-url`)
+        .set('X-Authorization', contentCreator.accessToken as any)
+        .expect(404);
+    });
+
+    it('succeeds when url is correct', async () => {
+      const { body } = await test.app
+        .delete(`/api/v3/creator/recommendations/${recommendations[0].urlId}`)
+        .set('X-Authorization', contentCreator.accessToken as any)
+        .expect(200);
+
+      expect(body).toBe(true);
     });
   });
 });

--- a/backend/routes/youchoose/deleteRecommendation.route.ts
+++ b/backend/routes/youchoose/deleteRecommendation.route.ts
@@ -19,13 +19,10 @@ export const DeleteRecommendationRoute: Route = (r, { db, logger }) => {
 
       return pipe(
         // connect to db
-        TE.tryCatch(async () => {
-          const check = await ycai.getCreatorByToken(
-            headers['x-authorization']
-          );
-          console.log(check);
-          return check;
-        }, toBackendError),
+        TE.tryCatch(
+          () => ycai.getCreatorByToken(headers['x-authorization']),
+          toBackendError
+        ),
         TE.chain((user) =>
           pipe(
             TE.tryCatch(

--- a/backend/routes/youchoose/deleteRecommendation.route.ts
+++ b/backend/routes/youchoose/deleteRecommendation.route.ts
@@ -1,0 +1,64 @@
+import {
+  NotFoundError,
+  toBackendError,
+} from '@shared/backend/errors/BackendError';
+import { Route } from '@shared/backend/types';
+import { authenticationMiddleware } from '@shared/backend/utils/authenticationMiddleware';
+import { AddEndpoint } from '@shared/backend/utils/endpoint';
+import * as Endpoints from '@shared/endpoints';
+import { pipe } from 'fp-ts/lib/pipeable';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as ycai from '../../lib/ycai';
+
+export const DeleteRecommendationRoute: Route = (r, { db, logger }) => {
+  AddEndpoint(r, authenticationMiddleware(logger))(
+    Endpoints.v3.Creator.DeleteRecommendation,
+    ({ params: { urlId }, headers }) => {
+      logger.debug('Authorized request %O', headers);
+      logger.debug('Delete recommendation by url id %s', urlId);
+
+      return pipe(
+        // connect to db
+        TE.tryCatch(async () => {
+          const check = await ycai.getCreatorByToken(
+            headers['x-authorization']
+          );
+          console.log(check);
+          return check;
+        }, toBackendError),
+        TE.chain((user) =>
+          pipe(
+            TE.tryCatch(
+              () =>
+                db.readOne(
+                  db.mongo,
+                  'recommendations',
+                  { urlId, channelId: user.channelId },
+                  {}
+                ),
+              toBackendError
+            ),
+            TE.filterOrElse(
+              (r) => r !== undefined,
+              () => NotFoundError('recommendations')
+            ),
+            TE.chain(() =>
+              TE.tryCatch(
+                () =>
+                  db.deleteMany(db.mongo, 'recommendations', {
+                    urlId,
+                    channelId: user.channelId,
+                  }),
+                toBackendError
+              )
+            )
+          )
+        ),
+        TE.map((result) => ({
+          body: result.acknowledged,
+          statusCode: 200,
+        }))
+      );
+    }
+  );
+};

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -7,7 +7,15 @@ module.exports = {
     'scope-enum': [
       2,
       'always',
-      ['workspace', 'guardoni', 'ycai', 'taboule', 'tktrex', 'yttrex'],
+      [
+        'workspace',
+        'shared',
+        'taboule',
+        'guardoni',
+        'ycai',
+        'tktrex',
+        'yttrex',
+      ],
     ],
     'type-enum': [
       2,

--- a/packages/shared/src/backend/errors/BackendError.ts
+++ b/packages/shared/src/backend/errors/BackendError.ts
@@ -4,13 +4,39 @@ export class BackendError extends IOError {
   public readonly name = 'BackendError';
 }
 
+export const NotAuthorizedError = (): BackendError => {
+  return {
+    name: 'BackendError',
+    status: 401,
+    message: 'Authorization header is missing',
+    details: {
+      kind: 'ClientError',
+      status: '401',
+    },
+  };
+};
+
+export const NotFoundError = (resource: string): BackendError => {
+  return {
+    name: 'BackendError',
+    status: 404,
+    message: `Can't find the resource ${resource}`,
+    details: {
+      kind: 'ClientError',
+      status: '404',
+    },
+  };
+};
+
 export const toBackendError = (e: unknown): BackendError => {
+  console.error(e);
   if (e instanceof Error) {
     return new BackendError(e.message, {
       kind: 'ServerError',
       status: e.name,
     });
   }
+
   return new BackendError('UnknownError', {
     kind: 'ServerError',
     status: 'Unknown',

--- a/packages/shared/src/backend/utils/authenticationMiddleware.ts
+++ b/packages/shared/src/backend/utils/authenticationMiddleware.ts
@@ -1,0 +1,34 @@
+import { NotAuthorizedError } from '../errors/BackendError';
+import * as express from 'express';
+import * as E from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/function';
+import * as t from 'io-ts';
+import { PathReporter } from 'io-ts/lib/PathReporter';
+import * as logger from '../../logger';
+
+const HeadersWithAuthorization = t.strict(
+  {
+    'x-authorization': t.string,
+  },
+  'HeadersWithAuthorization'
+);
+
+export const authenticationMiddleware: (
+  logger: logger.Logger
+) => express.RequestHandler = (l) => (req, _res, next) => {
+  const decodedHeaders = HeadersWithAuthorization.decode(req.headers);
+
+  l.debug('Decoded headers errors %O', PathReporter.report(decodedHeaders));
+
+  return pipe(
+    decodedHeaders,
+    E.mapLeft(() => NotAuthorizedError()),
+    E.fold(
+      (e) => next(e),
+      (d) => {
+        l.debug('Calling next handler...');
+        next();
+      }
+    )
+  );
+};

--- a/packages/shared/src/backend/utils/endpoint.ts
+++ b/packages/shared/src/backend/utils/endpoint.ts
@@ -1,14 +1,30 @@
+import { failure } from 'io-ts/lib/PathReporter';
 import { GetEndpointSubscriber } from 'ts-endpoint-express';
 import { IOError } from 'ts-io-error/lib';
 
-export const AddEndpoint = GetEndpointSubscriber((e): IOError => {
+const toError = (e: unknown): IOError => {
+  // console.log(e);
+  if (Array.isArray(e) && e[0].context !== undefined) {
+    return {
+      name: 'Validation Error',
+      status: 400,
+      message: 'Error during validation',
+      details: {
+        kind: 'DecodingError',
+        errors: failure(e),
+      },
+    };
+  }
+
   return {
     name: 'EndpointError',
     status: 500,
     message: 'Unknown error',
     details: {
       kind: 'DecodingError',
-      errors: e,
+      errors: [],
     },
   };
-});
+};
+
+export const AddEndpoint = GetEndpointSubscriber(toError);

--- a/packages/shared/src/endpoints/v3/creator.endpoints.ts
+++ b/packages/shared/src/endpoints/v3/creator.endpoints.ts
@@ -126,6 +126,16 @@ const PatchRecommendation = Endpoint({
   Output: Recommendation,
 });
 
+const DeleteRecommendation = Endpoint({
+  Method: 'DELETE',
+  getPath: ({ urlId }) => `/v3/creator/recommendations/${urlId}`,
+  Input: {
+    Headers: AuthorizationHeader,
+    Params: t.type({ urlId: t.string }),
+  },
+  Output: t.boolean,
+});
+
 const GetCreatorStats = Endpoint({
   Method: 'GET',
   getPath: ({ channelId }) => `/v3/creator/${channelId}/stats`,
@@ -142,10 +152,11 @@ export const endpoints = {
   CreatorVideos,
   OneCreatorVideo,
   CreatorRecommendations,
+  CreateRecommendation,
   PatchRecommendation,
+  DeleteRecommendation,
   CreatorRelatedChannels,
   UpdateVideo,
-  CreateRecommendation,
   PullCreatorVideos,
   GetCreatorStats,
 };


### PR DESCRIPTION
I added an "authentication middleware" to check the existence of the authorization header to use for authenticated routes.
For now it doesn't decode the token, nor fetch the user from the db but this can be easily solved.

At the moment I don't want to overload the server with a db call for each authenticated request and we would probably end up storing the user in the `jwt` token.