### PR TITLE
Fix(ycai): unauthorized request triggers a content creator logout

### DIFF
--- a/YCAI/src/api.ts
+++ b/YCAI/src/api.ts
@@ -1,8 +1,0 @@
-import { GetAPI } from '@shared/providers/api.provider';
-import { config } from './config';
-
-const { API, HTTPClient } = GetAPI({
-  baseURL: config.API_URL,
-});
-
-export { API, HTTPClient };

--- a/YCAI/src/app.tsx
+++ b/YCAI/src/app.tsx
@@ -9,7 +9,7 @@ import { config } from './config';
 import * as BrowserP from './providers/browser.provider';
 import { MessageType } from '@shared/providers/browser.provider';
 import { bo } from '@shared/utils/browser.utils';
-import { settingsRefetch } from './state/popup.queries';
+import { settingsRefetch } from './state/popup/popup.queries';
 import { Settings } from './models/Settings';
 import { YTContributionInfoBox } from './components/injected/YTContributionInfoBox';
 import { YTVideoPage } from './components/injected/YTVideoPage';

--- a/YCAI/src/background/index.ts
+++ b/YCAI/src/background/index.ts
@@ -15,7 +15,7 @@ import * as E from 'fp-ts/lib/Either';
 import { pipe } from 'fp-ts/lib/function';
 import * as O from 'fp-ts/lib/Option';
 import * as TE from 'fp-ts/lib/TaskEither';
-import { HTTPClient } from '../api';
+import { HTTPClient } from '../state/dashboard/public.queries';
 import { config } from '../config';
 import * as constants from '../constants';
 import { getDefaultSettings, Settings } from '../models/Settings';

--- a/YCAI/src/components/dashboard/Sidebar.tsx
+++ b/YCAI/src/components/dashboard/Sidebar.tsx
@@ -198,7 +198,7 @@ const MenuBox: React.FC<{ currentView: CurrentView }> = ({ currentView }) => {
 
 interface SidebarProps {
   currentView: CurrentView;
-  profile?: ContentCreator;
+  profile: ContentCreator | null;
   accountLinkCompleted: boolean;
 }
 

--- a/YCAI/src/components/dashboard/settings/AccessTokenBox.tsx
+++ b/YCAI/src/components/dashboard/settings/AccessTokenBox.tsx
@@ -1,4 +1,3 @@
-import { ContentCreator } from '@shared/models/ContentCreator';
 import {
   Box,
   Button,
@@ -11,23 +10,23 @@ import {
   InputAdornment,
   InputLabel,
   makeStyles,
-  Typography,
+  Typography
 } from '@material-ui/core';
 import CloudDownload from '@material-ui/icons/CloudDownload';
 import VisibilityIcon from '@material-ui/icons/Visibility';
 import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
-import * as E from 'fp-ts/lib/Either';
 import { APIError } from '@shared/errors/APIError';
+import { ContentCreator } from '@shared/models/ContentCreator';
+import * as E from 'fp-ts/lib/Either';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { assignAccessToken } from '../../../state/dashboard/creator.commands';
+import { assignAccessToken, deleteProfile } from '../../../state/dashboard/creator.commands';
 import {
-  deleteProfile,
-  downloadTXTFile,
+  downloadTXTFile
 } from '../../../state/dashboard/public.commands';
 import { YCAITheme } from '../../../theme';
-import UnlinkProfileButton from '../../common/UnlinkProfileButton';
 import { doUpdateCurrentView } from '../../../utils/location.utils';
+import UnlinkProfileButton from '../../common/UnlinkProfileButton';
 
 interface AccessTokenBoxProps {
   profile: ContentCreator | null;

--- a/YCAI/src/components/injected/DonationOptInNudger.tsx
+++ b/YCAI/src/components/injected/DonationOptInNudger.tsx
@@ -5,14 +5,14 @@ import { useTranslation } from 'react-i18next';
 import { Button, Link, Typography } from '@material-ui/core';
 import { makeStyles } from '@material-ui/styles';
 
-import { settings } from '../../state/popup.queries';
-import { donationOptInNudgeStatus } from '../../state/injected.queries';
-import { setDonationOptInNudgeStatus } from '../../state/injected.commands';
-import { updateSettings } from '../../state/popup.commands';
+import { settings } from '../../state/popup/popup.queries';
+import { donationOptInNudgeStatus } from '../../state/injected/injected.queries';
+import { setDonationOptInNudgeStatus } from '../../state/injected/injected.commands';
+import { updateSettings } from '../../state/popup/popup.commands';
 import { YCAITheme } from '../../theme';
 import { DATA_DONATION_LEARN_MORE_URL } from '../../constants';
 
-const useStyles = makeStyles<YCAITheme>(theme => ({
+const useStyles = makeStyles<YCAITheme>((theme) => ({
   box: {
     border: `1px solid ${theme.palette.divider}`,
     padding: theme.spacing(1),
@@ -24,91 +24,91 @@ const useStyles = makeStyles<YCAITheme>(theme => ({
   },
 }));
 
-const DonationOptInNudger: React.FC = () =>
+const DonationOptInNudger: React.FC = () => (
   <WithQueries
     queries={{ settings, donationOptInNudgeStatus }}
-    render={fold(() => null, () => null, ({ settings, donationOptInNudgeStatus }) => {
-      const { t } = useTranslation();
-      const classes = useStyles();
+    render={fold(
+      () => null,
+      () => null,
+      ({ settings, donationOptInNudgeStatus }) => {
+        const { t } = useTranslation();
+        const classes = useStyles();
 
-      const [showNudge, setShowNudge] = useState(false);
+        const [showNudge, setShowNudge] = useState(false);
 
-      useEffect(() => {
-        const { showNudgeTimes } = donationOptInNudgeStatus;
+        useEffect(() => {
+          const { showNudgeTimes } = donationOptInNudgeStatus;
 
-        if (showNudgeTimes.length === 0) {
-          return;
+          if (showNudgeTimes.length === 0) {
+            return;
+          }
+
+          const [nextNudgeTime] = showNudgeTimes;
+
+          const now = Date.now();
+
+          if (now >= nextNudgeTime) {
+            setShowNudge(true);
+            return;
+          }
+
+          const timeout = setTimeout(() => {
+            setShowNudge(true);
+          }, nextNudgeTime - now);
+
+          return () => clearTimeout(timeout);
+        }, []);
+
+        const handleNotNowClicked = (): void => {
+          // clicking on not now should hide the nudge until the next time stored
+          // in the local storage
+          setShowNudge(false);
+          const {
+            showNudgeTimes: [, ...remaining],
+          } = donationOptInNudgeStatus;
+          void setDonationOptInNudgeStatus({ showNudgeTimes: remaining })();
+        };
+
+        const handleAgreeClicked = (): void => {
+          void updateSettings({
+            ...settings,
+            independentContributions: {
+              ...settings.independentContributions,
+              enable: true,
+            },
+          })();
+          setShowNudge(false);
+        };
+
+        if (!showNudge || settings.independentContributions.enable) {
+          return null;
         }
 
-        const [nextNudgeTime] = showNudgeTimes;
+        return (
+          <div className={classes.box}>
+            <Typography className={classes.text}>
+              {t('settings:nudge_donation_opt_in')}
+              &nbsp;
+              <Link
+                href={DATA_DONATION_LEARN_MORE_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {t('settings:nudge_learn_more')}
+              </Link>
+            </Typography>
 
-        const now = Date.now();
-
-        if (now >= nextNudgeTime) {
-          setShowNudge(true);
-          return;
-        }
-
-        const timeout = setTimeout(() => {
-          setShowNudge(true);
-        }, nextNudgeTime - now);
-
-        return () => clearTimeout(timeout);
-      }, []);
-
-      const handleNotNowClicked = (): void => {
-        // clicking on not now should hide the nudge until the next time stored
-        // in the local storage
-        setShowNudge(false);
-        const { showNudgeTimes: [, ...remaining] } = donationOptInNudgeStatus;
-        void setDonationOptInNudgeStatus({ showNudgeTimes: remaining })();
-      };
-
-      const handleAgreeClicked = (): void => {
-        void updateSettings({
-          ...settings,
-          independentContributions: {
-            ...settings.independentContributions,
-            enable: true,
-          },
-        })();
-        setShowNudge(false);
-      };
-
-      if (!showNudge || settings.independentContributions.enable) {
-        return null;
+            <Button color="secondary" onClick={handleNotNowClicked}>
+              {t('settings:nudge_not_now')}
+            </Button>
+            <Button color="primary" onClick={handleAgreeClicked}>
+              {t('settings:nudge_agree')}
+            </Button>
+          </div>
+        );
       }
-
-      return (
-        <div className={classes.box}>
-          <Typography className={classes.text}>
-            {t('settings:nudge_donation_opt_in')}
-            &nbsp;
-            <Link
-              href={DATA_DONATION_LEARN_MORE_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {t('settings:nudge_learn_more')}
-            </Link>
-          </Typography>
-
-          <Button
-            color="secondary"
-            onClick={handleNotNowClicked}
-          >
-            {t('settings:nudge_not_now')}
-          </Button>
-          <Button
-            color="primary"
-            onClick={handleAgreeClicked}
-          >
-            {t('settings:nudge_agree')}
-          </Button>
-        </div>
-      );
-    }
     )}
-  />;
+  />
+);
 
 export default DonationOptInNudger;

--- a/YCAI/src/components/injected/YTContributionInfoBox.tsx
+++ b/YCAI/src/components/injected/YTContributionInfoBox.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { LazyFullSizeLoader } from '../../components/common/FullSizeLoader';
 import { Settings } from '../../models/Settings';
 import { dataDonation } from '../../providers/dataDonation.provider';
-import { keypair } from '../../state/popup.queries';
+import { keypair } from '../../state/popup/popup.queries';
 import { makeStyles } from '../../theme';
 
 const useStyles = makeStyles((props) => ({

--- a/YCAI/src/components/injected/YTVideoPage.tsx
+++ b/YCAI/src/components/injected/YTVideoPage.tsx
@@ -8,7 +8,7 @@ import { pipe } from 'fp-ts/lib/function';
 import { useTranslation } from 'react-i18next';
 import { getVideoId } from '@shared/utils/yt.utils';
 
-import { videoRecommendations } from '../../state/popup.queries';
+import { videoRecommendations } from '../../state/popup/popup.queries';
 import { FullSizeLoader } from '../common/FullSizeLoader';
 import { GetLogger } from '@shared/logger';
 import { Recommendation } from '@shared/models/Recommendation';

--- a/YCAI/src/components/popup/Popup.tsx
+++ b/YCAI/src/components/popup/Popup.tsx
@@ -15,7 +15,7 @@ import parseISO from 'date-fns/parseISO';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { config } from '../../config';
-import { settings } from '../../state/popup.queries';
+import { settings } from '../../state/popup/popup.queries';
 import { PopupErrorBox } from './PopupErrorBox';
 import Settings from './Settings';
 
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
     marginTop: theme.spacing(2),
     marginBottom: theme.spacing(0),
   },
-  version:{
+  version: {
     marginBottom: theme.spacing(7),
   },
   img: {
@@ -77,21 +77,13 @@ export const Popup: React.FC = () => {
   const classes = useStyles();
 
   const version = config.VERSION;
-  const timeAgo = formatDistance(
-    parseISO(config.BUILD_DATE),
-    new Date(),
-    {
-      addSuffix: true,
-    }
-  );
+  const timeAgo = formatDistance(parseISO(config.BUILD_DATE), new Date(), {
+    addSuffix: true,
+  });
 
   return (
     <Card className={classes.container}>
-      <Box
-        className={classes.header}
-        display="flex"
-        justifyContent="center"
-      >
+      <Box className={classes.header} display="flex" justifyContent="center">
         <a
           className={classes.link}
           href={config.WEB_URL}

--- a/YCAI/src/components/popup/PopupErrorBox.tsx
+++ b/YCAI/src/components/popup/PopupErrorBox.tsx
@@ -3,7 +3,7 @@ import { Box, Button, ButtonGroup } from '@material-ui/core';
 import { ErrorBox } from '@shared/components/Error/ErrorBox';
 import { getDefaultSettings } from '../../models/Settings';
 import { useTranslation } from 'react-i18next';
-import { updateSettings } from '../../state/popup.commands';
+import { updateSettings } from '../../state/popup/popup.commands';
 
 export const PopupErrorBox = (e: any): React.ReactElement => {
   const { t } = useTranslation();

--- a/YCAI/src/components/popup/Settings.tsx
+++ b/YCAI/src/components/popup/Settings.tsx
@@ -12,7 +12,10 @@ import {
 import { Folder as FolderIcon } from '@material-ui/icons';
 import { useTranslation } from 'react-i18next';
 import * as models from '../../models';
-import { generateKeypair, updateSettings } from '../../state/popup.commands';
+import {
+  generateKeypair,
+  updateSettings,
+} from '../../state/popup/popup.commands';
 import { DATA_DONATION_LEARN_MORE_URL } from '../../constants';
 
 const useStyles = makeStyles((theme) => ({
@@ -41,8 +44,8 @@ const useStyles = makeStyles((theme) => ({
     marginLeft: -6,
     '& svg': {
       height: 16,
-    }
-  }
+    },
+  },
 }));
 
 interface SettingsProps {
@@ -64,7 +67,10 @@ const Settings: React.FC<SettingsProps> = ({ settings }) => {
             color="primary"
             checked={settings.enhanceYouTubeExperience}
             onChange={(e, checked) =>
-              updateSettings({ ...settings, enhanceYouTubeExperience: checked })()
+              updateSettings({
+                ...settings,
+                enhanceYouTubeExperience: checked,
+              })()
             }
           />
         }

--- a/YCAI/src/state/dashboard/public.commands.ts
+++ b/YCAI/src/state/dashboard/public.commands.ts
@@ -4,9 +4,7 @@ import * as TE from 'fp-ts/lib/TaskEither';
 import { setItem } from '@shared/providers/localStorage.provider';
 import * as sharedConst from '@shared/constants';
 import { Settings } from '../../models/Settings';
-import { API } from '../../api';
-import { profile } from './creator.queries';
-import { keypair, settings, settingsRefetch } from './public.queries';
+import { keypair, settings, settingsRefetch, API } from './public.queries';
 
 export const handshake = command((handshake: HandshakeBody) =>
   API.v3.Public.Handshake({ Body: handshake })
@@ -24,11 +22,6 @@ export const deleteKeypair = command(() => TE.right({}), {
 export const updateSettings = command(
   (payload: Settings) => TE.fromIO(setItem(sharedConst.SETTINGS_KEY, payload)),
   { keypair, settings, settingsRefetch }
-);
-
-export const deleteProfile = command(
-  () => TE.fromIO(setItem(sharedConst.CONTENT_CREATOR, null)),
-  { profile }
 );
 
 export const downloadTXTFile = command(

--- a/YCAI/src/state/dashboard/public.queries.ts
+++ b/YCAI/src/state/dashboard/public.queries.ts
@@ -3,10 +3,18 @@ import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
 import { AppError } from '@shared/errors/AppError';
 import { getDefaultSettings } from '../../models/Settings';
-import { API } from '../../api';
 import * as localStorage from '@shared/providers/localStorage.provider';
 import * as sharedConstants from '@shared/constants';
 import { Keypair } from '@shared/models/extension/Keypair';
+import { GetAPI } from '@shared/providers/api.provider';
+import { config } from '../../config';
+
+export const { API, HTTPClient } = GetAPI({
+  baseURL: config.API_URL,
+  getAuth: async (req) => req,
+  onUnauthorized: async (res) => res,
+});
+
 
 export const settingsRefetch = queryShallow(() => {
   return pipe(

--- a/YCAI/src/state/injected/injected.commands.ts
+++ b/YCAI/src/state/injected/injected.commands.ts
@@ -1,6 +1,6 @@
 import { command } from 'avenger';
-import { browser, Messages } from '../providers/browser.provider';
-import { OptInNudgeStatus } from '../models/Settings';
+import { browser, Messages } from '../../providers/browser.provider';
+import { OptInNudgeStatus } from '../../models/Settings';
 import { donationOptInNudgeStatus } from './injected.queries';
 
 export const setDonationOptInNudgeStatus = command(

--- a/YCAI/src/state/injected/injected.queries.ts
+++ b/YCAI/src/state/injected/injected.queries.ts
@@ -2,8 +2,8 @@ import { pipe } from 'fp-ts/lib/function';
 import { chain, map, right } from 'fp-ts/lib/TaskEither';
 import { available, queryShallow } from 'avenger';
 
-import { getInitialOptInNudgeStatus } from '../models/Settings';
-import { browser, Messages } from '../providers/browser.provider';
+import { getInitialOptInNudgeStatus } from '../../models/Settings';
+import { browser, Messages } from '../../providers/browser.provider';
 
 export const donationOptInNudgeStatus = queryShallow(
   () =>

--- a/YCAI/src/state/popup/popup.commands.ts
+++ b/YCAI/src/state/popup/popup.commands.ts
@@ -1,10 +1,9 @@
 import { HandshakeBody } from '@shared/models/HandshakeBody';
 import { command } from 'avenger';
 import * as TE from 'fp-ts/lib/TaskEither';
-import { Messages, browser } from '../providers/browser.provider';
-import { Settings } from '../models/Settings';
-import { API } from '../api';
-import { settings, settingsRefetch, keypair } from './popup.queries';
+import { Messages, browser } from '../../providers/browser.provider';
+import { Settings } from '../../models/Settings';
+import { settings, settingsRefetch, keypair, API } from './popup.queries';
 
 export const handshake = command((handshake: HandshakeBody) =>
   API.v3.Public.Handshake({ Body: handshake })

--- a/YCAI/src/state/popup/popup.queries.ts
+++ b/YCAI/src/state/popup/popup.queries.ts
@@ -1,9 +1,42 @@
 import * as Endpoints from '@shared/endpoints';
-import { browser, Messages } from '../providers/browser.provider';
+import { GetAPI } from '@shared/providers/api.provider';
 import { available, queryShallow, queryStrict, refetch } from 'avenger';
 import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
-import { getDefaultSettings } from '../models/Settings';
+import { config } from '../../config';
+import { getDefaultSettings } from '../../models/Settings';
+import { browser, Messages } from '../../providers/browser.provider';
+
+/**
+ * The popup api client doesn't need any specific authorization
+ */
+export const { API } = GetAPI({
+  baseURL: config.API_URL,
+  getAuth: (req) =>
+    pipe(
+      browser.sendMessage(Messages.GetKeypair)(),
+      TE.fold(
+        (e) => () => Promise.resolve(req),
+        (k) => async () => {
+          // req.headers('X-YTtrex-Version', config.VERSION);
+          // req.headers('X-YTtrex-Build', config.BUILD);
+          // const signature = nacl.sign.detached(
+          //   decodeString(payload),
+          //   decodeKey(keypair.secretKey)
+          // );
+          // xhr.setRequestHeader('X-YTtrex-NonAuthCookieId', cookieId);
+          // xhr.setRequestHeader('X-YTtrex-PublicKey', keypair.publicKey);
+          // xhr.setRequestHeader('X-YTtrex-Signature', bs58.encode(signature));
+          // req.headers = {
+          //   ...req.headers,
+          //   Authorization: `Bearer ${k.publicKey}`,
+          // };
+          return Promise.resolve(req);
+        }
+      )
+    )(),
+  onUnauthorized: async (res) => res,
+});
 
 export const settingsRefetch = queryShallow(() => {
   return pipe(
@@ -50,6 +83,9 @@ export const videoRecommendations = queryShallow(
   available
 );
 
+/**
+ * Get keypair value by sending a message to the background script
+ */
 export const keypair = queryStrict(() => {
   return browser.sendMessage(Messages.GetKeypair)();
 }, refetch);

--- a/backend/bin/app.ts
+++ b/backend/bin/app.ts
@@ -40,9 +40,10 @@ const iowrapper =
         res.send('Fatal error: Invalid output');
         res.status(501);
       } else if (httpresult.json?.error) {
-        logger.debug('API (%s) failure, returning 500', fname);
+        const statusCode = httpresult.json.status ?? 500;
+        logger.debug('API (%s) failure, returning %d', fname, statusCode);
         loginc('errors', fname);
-        res.status(500);
+        res.status(statusCode);
         res.json(httpresult.json);
       } else if (httpresult.json) {
         // logger("API (%s) success, returning %d bytes JSON", fname, _.size(JSON.stringify(httpresult.json)));

--- a/backend/routes/__tests__/youchoose.e2e.ts
+++ b/backend/routes/__tests__/youchoose.e2e.ts
@@ -124,7 +124,7 @@ describe('The YouChoose API', () => {
         .get(`/api/v3/creator/me`)
         .send({ type: 'channel' })
         .set('X-Authorization', 'wrong-token')
-        .expect(500);
+        .expect(401);
     });
 
     it('succeeds with access token', async () => {
@@ -141,7 +141,7 @@ describe('The YouChoose API', () => {
     it('fails for missing header', async () => {
       const { body } = await test.app
         .post(`/api/v3/creator/videos/repull`)
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({ error: true });
     });
@@ -168,7 +168,7 @@ describe('The YouChoose API', () => {
 
   describe('Get Content Creator videos', () => {
     it('fails for missing header', async () => {
-      const { body } = await test.app.get(`/api/v3/creator/videos`).expect(500);
+      const { body } = await test.app.get(`/api/v3/creator/videos`).expect(400);
 
       expect(body).toMatchObject({ error: true });
     });
@@ -213,7 +213,7 @@ describe('The YouChoose API', () => {
     it('fails for missing token', async () => {
       const { body } = await test.app
         .get(`/api/v3/creator/videos/${videos[0].videoId}`)
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({ error: true });
     });
@@ -240,7 +240,7 @@ describe('The YouChoose API', () => {
       const { body } = await test.app
         .post(`/api/v3/creator/ogp`)
         .send({ videoId: videos[0].videoId, url: `http://fake-url/${uuid()}` })
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({ error: true });
     });
@@ -324,7 +324,7 @@ describe('The YouChoose API', () => {
           videoId: videos[0].videoId,
           recommendations: recommendationURLIds,
         })
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({ error: true });
     });
@@ -336,7 +336,7 @@ describe('The YouChoose API', () => {
         .send({
           recommendations: [],
         })
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({
         error: true,
@@ -350,7 +350,7 @@ describe('The YouChoose API', () => {
         .send({
           videoId: videos[0].videoId,
         })
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({
         error: true,
@@ -364,7 +364,7 @@ describe('The YouChoose API', () => {
         .send({
           recommendations: ['fake-id'],
         })
-        .expect(500);
+        .expect(400);
 
       expect(body).toMatchObject({
         error: true,

--- a/backend/routes/youchoose.js
+++ b/backend/routes/youchoose.js
@@ -25,6 +25,7 @@ async function verifyAuthorization(req, model) {
     return {
       creator: {
         error: true,
+        status: 400,
         details: decodedReq.result,
       },
     };
@@ -39,7 +40,7 @@ async function verifyAuthorization(req, model) {
     debug('Invalid token: %s, authorization fail', check);
   }
   /* else, the 'check' contains the creator object for the route */
-  return { creator: check, decodedReq };
+  return { creator: { ...check, status: 401 }, decodedReq };
 }
 
 async function byVideoId(req) {

--- a/packages/taboule/src/state/commands.ts
+++ b/packages/taboule/src/state/commands.ts
@@ -38,7 +38,11 @@ export const GetTabouleCommands = (
   },
   queries: TabouleQueries
 ): TabouleCommands => {
-  const API = GetAPI({ baseURL });
+  const API = GetAPI({
+    baseURL,
+    getAuth: async (req) => req,
+    onUnauthorized: async (res) => res,
+  });
   const deleteContribution = command(
     (input: { Params: { publicKey: string; selector: string | undefined } }) =>
       API.API.v2.Public.DeletePersonalContributionByPublicKey({

--- a/packages/taboule/src/state/queries.ts
+++ b/packages/taboule/src/state/queries.ts
@@ -55,7 +55,11 @@ export const GetTabouleQueries = ({
   baseURL,
   accessToken,
 }: GetTabouleQueriesProps): TabouleQueries => {
-  const { API } = GetAPI({ baseURL });
+  const { API } = GetAPI({
+    baseURL,
+    getAuth: async (req) => req,
+    onUnauthorized: async (res) => res,
+  });
 
   const ccRelatedUsers = queryStrict<
     SearchRequestInput,


### PR DESCRIPTION
I've updated the `api.provider` to accept options with the following shape

```ts
interface GetAPIOptions {
  baseURL: string;
  getAuth: (req: AxiosRequestConfig) => Promise<AxiosRequestConfig>;
  onUnauthorized: (res: AxiosResponse) => Promise<AxiosResponse>;
}
```

in order to connect the authentication with the api responses.

I also splitted the clients between "authenticated" and "public"