### PR TITLE
fix(ycai): content creator related with no nullable 'recommendedSource'

### DIFF
--- a/backend/lib/automo.js
+++ b/backend/lib/automo.js
@@ -228,6 +228,7 @@ async function getMetadataFromAuthorChannelId(channelId, options) {
   const mongoc = await mongo3.clientConnect({ concurrency: 1 });
   const filter = {
     authorSource: { $in: [`/channel/${channelId}`, `/c/${channelId}`] },
+    authorName: { $ne: null },
   };
 
   const cappedResultsOpts = [


### PR DESCRIPTION
I've fixed the issue was having @margelacool last week by excluding channels with "authorName" equal to `null` to be returned.

