### PR TITLE
fix(guardoni): profile loading, selection and creation, closes #518

### DIFF
--- a/platforms/guardoni/__tests__/cli.spec.ts
+++ b/platforms/guardoni/__tests__/cli.spec.ts
@@ -38,8 +38,8 @@ describe('CLI', () => {
       recursive: true,
     });
 
-    fs.statSync(ytExtensionDir, { throwIfNoEntry: true })
-    fs.statSync(tkExtensionDir, { throwIfNoEntry: true })
+    fs.statSync(ytExtensionDir, { throwIfNoEntry: true });
+    fs.statSync(tkExtensionDir, { throwIfNoEntry: true });
 
     const comparisonCSVContent = await csvStringifyTE(
       tests.fc.sample(ComparisonDirectiveRowArb, 5),
@@ -91,12 +91,14 @@ describe('CLI', () => {
         yt: {
           name: 'youtube',
           backend: process.env.YT_BACKEND as string,
+          frontend: undefined,
           extensionDir: ytExtensionDir,
           proxy: undefined,
         },
         tk: {
           name: 'tiktok',
           backend: process.env.TK_BACKEND as string,
+          frontend: undefined,
           extensionDir: tkExtensionDir,
           proxy: undefined,
         },
@@ -434,12 +436,14 @@ describe('CLI', () => {
         yt: {
           name: 'youtube',
           backend: process.env.YT_BACKEND as string,
+          frontend: undefined,
           extensionDir: ytExtensionDir,
           proxy: undefined,
         },
         tk: {
           name: 'tiktok',
           backend: process.env.TK_BACKEND as string,
+          frontend: undefined,
           extensionDir: tkExtensionDir,
           proxy: undefined,
         },

--- a/platforms/guardoni/__tests__/guardoni/guardoni.spec.ts
+++ b/platforms/guardoni/__tests__/guardoni/guardoni.spec.ts
@@ -56,12 +56,14 @@ describe('Guardoni', () => {
     yt: {
       name: 'youtube' as const,
       backend: process.env.YT_BACKEND as string,
+      frontend: process.env.YT_FRONTEND as string,
       extensionDir: path.resolve(__dirname, '../../../yttrex/extension/build'),
       proxy: undefined,
     },
     tk: {
       name: 'tiktok' as const,
       backend: process.env.TK_BACKEND as string,
+      frontend: process.env.TK_FRONTEND as string,
       extensionDir: path.resolve(__dirname, '../../../tktrex/extension/build'),
       proxy: undefined,
     },

--- a/platforms/guardoni/src/electron/app/App.tsx
+++ b/platforms/guardoni/src/electron/app/App.tsx
@@ -3,11 +3,7 @@ import { ipcRenderer } from 'electron';
 import * as React from 'react';
 import { Redirect, Route, Switch, useHistory } from 'react-router';
 import { v4 as uuid } from 'uuid';
-import {
-  GuardoniConfig,
-  GuardoniPlatformConfig,
-  Platform,
-} from '../../guardoni/types';
+import { GuardoniConfig, PlatformConfig, Platform } from '../../guardoni/types';
 import { EVENTS } from '../models/events';
 import ExperimentExecutionRoute from './components/ExperimentExecution';
 import ExperimentList from './components/ExperimentList';
@@ -19,7 +15,7 @@ export const App: React.FC = () => {
 
   const [{ config, platform, profiles }, setConfig] = React.useState<{
     config: GuardoniConfig | undefined;
-    platform: GuardoniPlatformConfig | undefined;
+    platform: PlatformConfig | undefined;
     profiles: string[];
   }>({ config: undefined, platform: undefined, profiles: [] });
 

--- a/platforms/guardoni/src/electron/app/App.tsx
+++ b/platforms/guardoni/src/electron/app/App.tsx
@@ -17,10 +17,11 @@ import Layout from './Layout';
 export const App: React.FC = () => {
   const history = useHistory();
 
-  const [{ config, platform }, setConfig] = React.useState<{
+  const [{ config, platform, profiles }, setConfig] = React.useState<{
     config: GuardoniConfig | undefined;
     platform: GuardoniPlatformConfig | undefined;
-  }>({ config: undefined, platform: undefined });
+    profiles: string[];
+  }>({ config: undefined, platform: undefined, profiles: [] });
 
   const [outputItems, setOutputItems] = React.useState<OutputItem[]>([]);
 
@@ -61,8 +62,8 @@ export const App: React.FC = () => {
     // update state when guardoni config has been received
     ipcRenderer.on(
       EVENTS.GET_GUARDONI_CONFIG_EVENT.value,
-      (event, { config, platform }) => {
-        setConfig({ config, platform });
+      (event, { config, platform, profiles }) => {
+        setConfig({ config, platform, profiles });
       }
     );
 
@@ -83,6 +84,7 @@ export const App: React.FC = () => {
     <Layout
       config={config}
       platform={platform}
+      profiles={profiles}
       onConfigChange={handleConfigChange}
       onPlatformChange={handlePlatformChange}
     >

--- a/platforms/guardoni/src/electron/app/Header.tsx
+++ b/platforms/guardoni/src/electron/app/Header.tsx
@@ -72,15 +72,10 @@ export const Header: React.FC<HeaderProps> = ({
   const [advancedSettingDialogOpen, setAdvancedSettingDialogOpen] =
     React.useState(false);
 
-  const [avatar, setAvatar] = React.useState(
-    botAvatars.create(config.profileName)
+  const avatar = React.useMemo(
+    () => botAvatars.create(config.profileName),
+    [config.profileName]
   );
-
-  React.useEffect(() => {
-    setAvatar(
-      botAvatars.create(`${config.profileName}-${Math.random() * 1000}`)
-    );
-  }, []);
 
   return (
     <AppBar

--- a/platforms/guardoni/src/electron/app/Header.tsx
+++ b/platforms/guardoni/src/electron/app/Header.tsx
@@ -16,11 +16,7 @@ import AddIcon from '@material-ui/icons/AddCircleOutline';
 import SettingsIcon from '@material-ui/icons/Settings';
 import PolicyIcon from '@material-ui/icons/Policy';
 import * as React from 'react';
-import {
-  GuardoniConfig,
-  GuardoniPlatformConfig,
-  Platform,
-} from '../../guardoni/types';
+import { GuardoniConfig, PlatformConfig, Platform } from '../../guardoni/types';
 import TKLogo from './icons/TKLogo';
 import YTLogo from './icons/YTLogo';
 import AdvancedSettingModal from './modals/AdvancedSettingModal';
@@ -58,7 +54,7 @@ const useStyles = makeStyles((theme) => ({
 
 export interface HeaderProps {
   config: GuardoniConfig;
-  platform: GuardoniPlatformConfig;
+  platform: PlatformConfig;
   profiles: string[];
   onConfigChange: (c: GuardoniConfig) => void;
   onPlatformChange: (p: Platform) => void;

--- a/platforms/guardoni/src/electron/app/Header.tsx
+++ b/platforms/guardoni/src/electron/app/Header.tsx
@@ -5,7 +5,9 @@ import {
   Button,
   Divider,
   makeStyles,
+  MenuItem,
   Popover,
+  Select,
   Toolbar,
   Typography,
   useTheme,
@@ -26,6 +28,7 @@ import cx from 'classnames';
 import botttsSprites from '@dicebear/avatars-bottts-sprites';
 import Avatars from '@dicebear/avatars';
 import { useHistory } from 'react-router';
+import AddProfileModal from './modals/AddProfileModal';
 
 const botAvatars = new Avatars(botttsSprites, { r: 50, base64: true });
 
@@ -43,6 +46,9 @@ const useStyles = makeStyles((theme) => ({
   platformLogoSelected: {
     opacity: 1,
   },
+  profileSelect: {
+    minWidth: '50%',
+  },
   settingButton: {
     ...theme.typography.body1,
     margin: theme.spacing(1),
@@ -53,6 +59,7 @@ const useStyles = makeStyles((theme) => ({
 export interface HeaderProps {
   config: GuardoniConfig;
   platform: GuardoniPlatformConfig;
+  profiles: string[];
   onConfigChange: (c: GuardoniConfig) => void;
   onPlatformChange: (p: Platform) => void;
 }
@@ -60,6 +67,7 @@ export interface HeaderProps {
 export const Header: React.FC<HeaderProps> = ({
   config,
   platform,
+  profiles,
   onConfigChange,
   onPlatformChange,
 }) => {
@@ -69,6 +77,7 @@ export const Header: React.FC<HeaderProps> = ({
   const classes = useStyles();
   const history = useHistory();
   const [popoverOpen, setPopoverOpen] = React.useState(false);
+  const [addProfileDialogOpen, setAddProfileDialogOpen] = React.useState(false);
   const [advancedSettingDialogOpen, setAdvancedSettingDialogOpen] =
     React.useState(false);
 
@@ -193,7 +202,23 @@ export const Header: React.FC<HeaderProps> = ({
               >
                 Profile Name
               </Typography>
-              <Typography variant="body1">{config.profileName}</Typography>
+              <Select
+                id="profileName"
+                className={classes.profileSelect}
+                value={config.profileName}
+                onChange={(e) => {
+                  onConfigChange({
+                    ...config,
+                    profileName: e.target.value as string,
+                  });
+                }}
+              >
+                {profiles.map((p) => (
+                  <MenuItem key={p} value={p}>
+                    {p}
+                  </MenuItem>
+                ))}
+              </Select>
               <Divider
                 style={{
                   width: '50%',
@@ -205,6 +230,9 @@ export const Header: React.FC<HeaderProps> = ({
               <Button
                 className={classes.settingButton}
                 startIcon={<AddIcon color="primary" />}
+                onClick={() => {
+                  setAddProfileDialogOpen(true);
+                }}
               >
                 Add profile
               </Button>
@@ -234,6 +262,14 @@ export const Header: React.FC<HeaderProps> = ({
         onConfigChange={onConfigChange}
         onCancel={() => {
           setAdvancedSettingDialogOpen(false);
+        }}
+      />
+      <AddProfileModal
+        open={addProfileDialogOpen}
+        config={config}
+        onConfigChange={onConfigChange}
+        onCancel={() => {
+          setAddProfileDialogOpen(false);
         }}
       />
     </AppBar>

--- a/platforms/guardoni/src/electron/app/components/ExperimentExecution.tsx
+++ b/platforms/guardoni/src/electron/app/components/ExperimentExecution.tsx
@@ -1,18 +1,20 @@
 import { Box, Button, Grid, Typography, useTheme } from '@material-ui/core';
+import LinkIcon from '@material-ui/icons/LinkOutlined';
+import { GuardoniExperiment } from '@shared/models/Experiment';
 import { BrowserView, ipcRenderer, shell } from 'electron';
 import * as React from 'react';
 import { RouteComponentProps, useHistory } from 'react-router';
-import { GuardoniPlatformConfig } from '../../../guardoni/types';
+import { PlatformConfig } from '../../../guardoni/types';
 import { EVENTS } from '../../models/events';
 import ElectronBrowserView from './browser-view/ElectronBrowserView';
 import OutputPanel from './OutputPanel';
-import LinkIcon from '@material-ui/icons/LinkOutlined';
-import { GuardoniExperiment } from '@shared/models/Experiment';
 
 interface ExperimentExecutionProps {
+  platformConfig: PlatformConfig;
   experiment: GuardoniExperiment;
   onClose: () => void;
   onRun: (experimentId: string) => void;
+  onOpenExperiment: (experimentId: string) => void;
   onOpenExperimentResults: (experimentId: string) => void;
   onOpenResults: (publicKey: string) => void;
 }
@@ -35,9 +37,11 @@ type ExperimentExecutionStatePhase =
     };
 
 const ExperimentExecution: React.FC<ExperimentExecutionProps> = ({
+  platformConfig,
   experiment,
   onClose,
   onRun,
+  onOpenExperiment,
   onOpenExperimentResults,
   onOpenResults,
 }) => {
@@ -112,7 +116,14 @@ const ExperimentExecution: React.FC<ExperimentExecutionProps> = ({
             <Typography variant="h4">Experiment</Typography>
           </Box>
           <Box>
-            <Typography>{experiment.experimentId}</Typography>
+            <Typography
+              onClick={() => onOpenExperiment(experiment.experimentId)}
+              style={{
+                cursor: 'pointer',
+              }}
+            >
+              {experiment.experimentId}
+            </Typography>
             <Box
               style={{
                 display: 'flex',
@@ -208,7 +219,14 @@ const ExperimentExecution: React.FC<ExperimentExecutionProps> = ({
                 </Typography>
               </Box>
               <Typography variant="body1">
-                <b>Experiment id:</b> {phase.payload.values.experimentId}
+                <b>Experiment id:</b>{' '}
+                <span
+                  onClick={() => {
+                    onOpenExperiment(phase.payload.values.experimentId);
+                  }}
+                >
+                  {phase.payload.values.experimentId}
+                </span>
               </Typography>
               <Typography variant="body1">
                 <b>Public Key:</b> {phase.payload.values.publicKey}
@@ -249,7 +267,7 @@ const ExperimentExecution: React.FC<ExperimentExecutionProps> = ({
 
 const ExperimentExecutionRoute: React.FC<
   RouteComponentProps<{ experimentId: string }> & {
-    config: GuardoniPlatformConfig;
+    config: PlatformConfig;
   }
 > = ({ config, match }) => {
   const history = useHistory();
@@ -266,6 +284,12 @@ const ExperimentExecutionRoute: React.FC<
     },
     [match.params.experimentId]
   );
+
+  const onOpenExperiment = React.useCallback((experimentId: string) => {
+    void shell.openExternal(
+      `${config.frontend}/experiments/render/#${experimentId}`
+    );
+  }, []);
 
   const onOpenExperimentResults = React.useCallback((experimentId: string) => {
     void shell.openExternal(
@@ -303,8 +327,10 @@ const ExperimentExecutionRoute: React.FC<
   return (
     <ExperimentExecution
       experiment={experiment}
+      platformConfig={config}
       onClose={onClose}
       onRun={onRun}
+      onOpenExperiment={onOpenExperiment}
       onOpenExperimentResults={onOpenExperimentResults}
       onOpenResults={onOpenResults}
     />

--- a/platforms/guardoni/src/electron/app/components/ExperimentList.tsx
+++ b/platforms/guardoni/src/electron/app/components/ExperimentList.tsx
@@ -19,7 +19,7 @@ import { formatDistanceToNow, parseISO } from 'date-fns';
 import { ipcRenderer } from 'electron';
 import * as React from 'react';
 import { RouteProps, useHistory } from 'react-router';
-import { GuardoniPlatformConfig } from '../../../guardoni/types';
+import { PlatformConfig } from '../../../guardoni/types';
 import { EVENTS } from '../../models/events';
 
 const useStyle = makeStyles((theme) => ({
@@ -167,7 +167,7 @@ export const ExperimentList: React.FC<ExperimentListProps> = ({
 };
 
 const ExperimentListRoute: React.FC<
-  RouteProps & { config: GuardoniPlatformConfig }
+  RouteProps & { config: PlatformConfig }
 > = ({ config }) => {
   const theme = useTheme();
   const [experiments, setDirectives] = React.useState<GuardoniExperiment[]>([]);

--- a/platforms/guardoni/src/electron/app/modals/AddProfileModal.tsx
+++ b/platforms/guardoni/src/electron/app/modals/AddProfileModal.tsx
@@ -1,0 +1,118 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+  Input,
+  makeStyles,
+} from '@material-ui/core';
+import { ipcRenderer } from 'electron';
+import * as React from 'react';
+import { GuardoniConfig } from '../../../guardoni/types';
+import { EVENTS } from '../../models/events';
+
+const useStyles = makeStyles((theme) => ({
+  formControl: {
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    marginTop: theme.spacing(3),
+    '& > .MuiFormControlLabel-label': { fontWeight: 600 },
+  },
+  formControlCheckbox: {
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    margin: 5,
+  },
+  formControlWithMarginBottom: {
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    margin: 0,
+    marginBottom: theme.spacing(4),
+  },
+}));
+
+const AddProfileModal: React.FC<{
+  open: boolean;
+  config: GuardoniConfig;
+  onConfigChange: (c: GuardoniConfig) => void;
+  onCancel: () => void;
+}> = ({ open, config: _config, onConfigChange, onCancel }) => {
+  const classes = useStyles();
+
+  const [config, setConfig] = React.useState<GuardoniConfig>(_config);
+
+  const handleOpenProfileDir = React.useCallback(
+    (c: GuardoniConfig) => {
+      ipcRenderer.send(
+        EVENTS.OPEN_GUARDONI_DIR.value,
+        `${c.basePath}/profiles/${c.profileName}`
+      );
+    },
+    [config]
+  );
+
+  return (
+    <Dialog open={open}>
+      <Grid container style={{ marginBottom: 20 }}>
+        <Grid item md={12}>
+          <Box display="flex" flexDirection="column" width="100%">
+            <FormControlLabel
+              label="Profile"
+              className={classes.formControl}
+              labelPlacement="top"
+              control={
+                <Input
+                  id="profile-path"
+                  aria-describedby="profile-path-text"
+                  value={config.profileName}
+                  fullWidth
+                  onChange={(e) =>
+                    setConfig({
+                      ...config,
+                      profileName: e.target.value,
+                    })
+                  }
+                />
+              }
+            />
+            <FormHelperText>
+              The profile data will be stored in {config.basePath}
+              /profiles/{config.profileName}
+            </FormHelperText>
+            <Box display="flex" flexDirection="row">
+              <Button
+                size="small"
+                color="primary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleOpenProfileDir(config);
+                }}
+                style={{ marginLeft: 12 }}
+              >
+                Open Profile Folder
+              </Button>
+            </Box>
+          </Box>
+        </Grid>
+      </Grid>
+      <DialogActions>
+        <Button onClick={() => onCancel()}>Cancel</Button>
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={() => {
+            onConfigChange(config);
+            onCancel();
+          }}
+        >
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default AddProfileModal;

--- a/platforms/guardoni/src/electron/app/modals/AdvancedSettingModal.tsx
+++ b/platforms/guardoni/src/electron/app/modals/AdvancedSettingModal.tsx
@@ -15,10 +15,7 @@ import {
   getConfigPlatformKey,
   getPlatformConfig,
 } from '../../../guardoni/config';
-import {
-  GuardoniConfig,
-  GuardoniPlatformConfig,
-} from '../../../guardoni/types';
+import { GuardoniConfig, PlatformConfig } from '../../../guardoni/types';
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
@@ -43,7 +40,7 @@ const useStyles = makeStyles((theme) => ({
 const AdvancedSettingModal: React.FC<{
   open: boolean;
   config: GuardoniConfig;
-  platform: GuardoniPlatformConfig;
+  platform: PlatformConfig;
   onConfigChange: (c: GuardoniConfig) => void;
   onCancel: () => void;
 }> = ({

--- a/platforms/guardoni/src/electron/app/modals/AdvancedSettingModal.tsx
+++ b/platforms/guardoni/src/electron/app/modals/AdvancedSettingModal.tsx
@@ -10,7 +10,6 @@ import {
   Input,
   makeStyles,
 } from '@material-ui/core';
-import { ipcRenderer } from 'electron';
 import * as React from 'react';
 import {
   getConfigPlatformKey,
@@ -20,7 +19,6 @@ import {
   GuardoniConfig,
   GuardoniPlatformConfig,
 } from '../../../guardoni/types';
-import { EVENTS } from '../../models/events';
 
 const useStyles = makeStyles((theme) => ({
   formControl: {
@@ -61,77 +59,11 @@ const AdvancedSettingModal: React.FC<{
   const platformKey = getConfigPlatformKey(_platform.name);
   const platform = getPlatformConfig(_platform.name, config);
 
-  const handleOpenProfileDir = React.useCallback(
-    (c: GuardoniConfig) => {
-      ipcRenderer.send(
-        EVENTS.OPEN_GUARDONI_DIR.value,
-        `${c.basePath}/profiles/${c.profileName}`
-      );
-    },
-    [config]
-  );
-
   return (
     <Dialog open={open}>
       <Grid container style={{ marginBottom: 20 }}>
         <Grid item md={12}>
           <Box display="flex" flexDirection="column" width="100%">
-            <FormControlLabel
-              label="Profile"
-              className={classes.formControl}
-              labelPlacement="top"
-              control={
-                <Input
-                  id="profile-path"
-                  aria-describedby="profile-path-text"
-                  value={config.profileName}
-                  fullWidth
-                  onChange={(e) =>
-                    setConfig({
-                      ...config,
-                      profileName: e.target.value,
-                    })
-                  }
-                />
-              }
-            />
-            <FormHelperText>
-              The profile data will be stored in {config.basePath}
-              /profiles/{config.profileName}
-            </FormHelperText>
-            <Box display="flex" flexDirection="row">
-              <Button
-                size="small"
-                color="primary"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  handleOpenProfileDir(config);
-                }}
-                style={{ marginLeft: 12 }}
-              >
-                Open Profile Folder
-              </Button>
-            </Box>
-          </Box>
-          <Box display="flex" flexDirection="column" width="100%">
-            {/* <FormControlLabel
-                  label="Evidence Tag"
-                  className={`${classes.formControl} ${classes.formControlWithMarginBottom}`}
-                  labelPlacement="top"
-                  control={
-                    <Input
-                      id="evidence-tag-input"
-                      value={config.evidenceTag}
-                      fullWidth
-                      onChange={(e) =>
-                        onConfigChange({
-                          ...config,
-                          evidenceTag: e.target.value,
-                        })
-                      }
-                    />
-                  }
-                /> */}
             <FormControlLabel
               label="Backend"
               className={classes.formControl}

--- a/platforms/guardoni/src/electron/events/renderer.events.ts
+++ b/platforms/guardoni/src/electron/events/renderer.events.ts
@@ -29,7 +29,7 @@ import { EVENTS } from '../models/events';
 import store from '../store';
 import { getEventsLogger } from './event.logger';
 import * as path from 'path';
-import { getProfileDataDir } from '../../guardoni/profile';
+import { getExistingProfiles, getProfileDataDir } from '../../guardoni/profile';
 
 const guardoniEventsLogger = guardoniLogger.extend('events');
 
@@ -181,7 +181,13 @@ export const GetEvents = ({
           );
 
           void pipe(
-            TE.right({ config: guardoni.config, platform: guardoni.platform }),
+            TE.right({
+              config: guardoni.config,
+              platform: guardoni.platform,
+              profiles: getExistingProfiles({ logger })(
+                guardoni.config.basePath
+              ),
+            }),
             liftEventTask(EVENTS.GET_GUARDONI_CONFIG_EVENT.value)
           );
         });
@@ -372,7 +378,13 @@ export const GetEvents = ({
         return TE.tryCatch(
           () =>
             liftEventTask(EVENTS.GET_GUARDONI_CONFIG_EVENT.value)(
-              TE.right({ config: guardoni.config, platform: guardoni.platform })
+              TE.right({
+                config: guardoni.config,
+                platform: guardoni.platform,
+                profiles: getExistingProfiles({ logger })(
+                  guardoni.config.basePath
+                ),
+              })
             ),
           toAppError
         );

--- a/platforms/guardoni/src/electron/events/renderer.events.ts
+++ b/platforms/guardoni/src/electron/events/renderer.events.ts
@@ -19,11 +19,7 @@ import {
   Guardoni,
   readCSVAndParse,
 } from '../../guardoni/guardoni';
-import {
-  GuardoniConfig,
-  GuardoniPlatformConfig,
-  Platform,
-} from '../../guardoni/types';
+import { GuardoniConfig, PlatformConfig, Platform } from '../../guardoni/types';
 import { guardoniLogger } from '../../logger';
 import { EVENTS } from '../models/events';
 import store from '../store';
@@ -61,7 +57,10 @@ const pickCSVFile = (
     TE.chain((value) => {
       return pipe(
         readCSVAndParse(logger)(value.filePaths[0], 'comparison'),
-        TE.map((parsed) => ({ path: value.filePaths[0], parsed }))
+        TE.map((parsed) => ({
+          path: value.filePaths[0],
+          parsed: parsed as any,
+        }))
       );
     })
   );
@@ -244,7 +243,7 @@ export const GetEvents = ({
           EVENTS.RUN_GUARDONI_EVENT.value,
           (
             event,
-            configOverride: GuardoniPlatformConfig,
+            configOverride: PlatformConfig,
             experimentId: NonEmptyString
           ) => {
             // eslint-disable-next-line no-console

--- a/platforms/guardoni/src/electron/main.ts
+++ b/platforms/guardoni/src/electron/main.ts
@@ -21,7 +21,6 @@ import { GetEvents } from './events/renderer.events';
 import store from './store';
 import { createGuardoniWindow } from './windows/GuardoniWindow';
 
-app.setPath('userData', path.resolve(os.homedir(), `.guardoni/electron/data`));
 app.setAppLogsPath(path.resolve(os.homedir(), `.guardoni/electron/logs`));
 
 // load env from .env file shipped with compiled code
@@ -126,10 +125,7 @@ export const run = async (): Promise<void> => {
             browser: guardoniApp.browser,
           });
 
-          return rendererEvents.register(basePath, platform, {
-            headless: false,
-            verbose: false,
-          });
+          return rendererEvents.register(basePath, platform, {});
         })
       );
     }),

--- a/platforms/guardoni/src/guardoni/browser.ts
+++ b/platforms/guardoni/src/guardoni/browser.ts
@@ -42,13 +42,15 @@ export const dispatchBrowser = (
     );
   }
   return TE.tryCatch(async () => {
-    // puppeteer.use(pluginStealth());
-    const browser = await ctx.puppeteer.launch({
+    // ctx.puppeteer.use(pluginStealth());
+    const opts = {
       headless: ctx.config.headless,
       userDataDir: ctx.profile.udd,
       executablePath: ctx.config.chromePath,
       args: commandLineArg,
-    });
+    };
+    ctx.logger.info('Launch puppeteer %O', opts);
+    const browser = await ctx.puppeteer.launch(opts);
 
     return browser;
   }, toAppError);

--- a/platforms/guardoni/src/guardoni/config.ts
+++ b/platforms/guardoni/src/guardoni/config.ts
@@ -13,13 +13,15 @@ import {
   DEFAULT_LOAD_FOR,
   DEFAULT_TK_BACKEND,
   DEFAULT_TK_EXTENSION_DIR,
+  DEFAULT_TK_FRONTEND,
   DEFAULT_YT_BACKEND,
   DEFAULT_YT_EXTENSION_DIR,
+  DEFAULT_YT_FRONTEND,
 } from './constants';
 import {
   GuardoniConfig,
   GuardoniContext,
-  GuardoniPlatformConfig,
+  PlatformConfig,
   Platform,
 } from './types';
 import { CHROME_PATHS, getChromePath } from './utils';
@@ -40,12 +42,14 @@ export const getDefaultConfig = (basePath: string): GuardoniConfig => {
     yt: {
       name: 'youtube',
       backend: DEFAULT_YT_BACKEND,
+      frontend: DEFAULT_YT_FRONTEND,
       extensionDir: DEFAULT_YT_EXTENSION_DIR,
       proxy: undefined,
     },
     tk: {
       name: 'tiktok',
       backend: DEFAULT_TK_BACKEND,
+      frontend: DEFAULT_TK_FRONTEND,
       extensionDir: DEFAULT_TK_EXTENSION_DIR,
       proxy: undefined,
     },
@@ -196,7 +200,7 @@ export const readConfigFromPath =
 export const getPlatformConfig = (
   p: Platform,
   { tk, yt, ...config }: GuardoniConfig
-): Omit<GuardoniPlatformConfig, 'basePath' | 'chromePath' | 'evidenceTag'> => {
+): PlatformConfig => {
   const platformConfigKey = getConfigPlatformKey(p);
 
   const platformConf = platformConfigKey === 'tk' ? tk : yt;
@@ -205,9 +209,16 @@ export const getPlatformConfig = (
     ? platformConf.extensionDir
     : path.resolve(config.basePath, platformConf.extensionDir);
 
+  // ensure frontend always exists
+  const frontend =
+    platformConf.frontend ?? platformConfigKey === 'tk'
+      ? DEFAULT_TK_FRONTEND
+      : DEFAULT_YT_FRONTEND;
+
   return {
     ...platformConf,
     extensionDir,
+    frontend,
   };
 };
 

--- a/platforms/guardoni/src/guardoni/constants.ts
+++ b/platforms/guardoni/src/guardoni/constants.ts
@@ -8,16 +8,16 @@ export const DEFAULT_EXTENSION_DIR = path.resolve(
 );
 
 // yt defaults
-export const DEFAULT_YT_BACKEND =
-  process.env.YT_BACKEND ?? 'https://youtube.tracking.exposed/api';
+export const DEFAULT_YT_FRONTEND = 'https://youtube.tracking.exposed';
+export const DEFAULT_YT_BACKEND = `${DEFAULT_YT_FRONTEND}/api`;
 export const DEFAULT_YT_EXTENSION_DIR = path.resolve(
   DEFAULT_EXTENSION_DIR,
   'yt'
 );
 
 // tk defaults
-export const DEFAULT_TK_BACKEND =
-  process.env.TK_BACKEND ?? 'https://youtube.tracking.exposed/api';
+export const DEFAULT_TK_FRONTEND = 'https://tiktok.tracking.exposed';
+export const DEFAULT_TK_BACKEND = `${DEFAULT_TK_FRONTEND}/api`;
 export const DEFAULT_TK_EXTENSION_DIR = path.resolve(
   DEFAULT_EXTENSION_DIR,
   'tk'

--- a/platforms/guardoni/src/guardoni/guardoni.ts
+++ b/platforms/guardoni/src/guardoni/guardoni.ts
@@ -238,7 +238,9 @@ export const guardoniExecution =
       experiment,
       directiveType
     );
+
     ctx.logger.debug('Experiment data %O', directives);
+    ctx.logger.debug('Config %O', ctx.config);
 
     return pipe(
       TE.tryCatch(

--- a/platforms/guardoni/src/guardoni/profile.ts
+++ b/platforms/guardoni/src/guardoni/profile.ts
@@ -73,7 +73,7 @@ export const checkProfile =
     ctx.logger.debug('Profile dir %s exists?', profileDir, profileDirExists);
 
     if (!profileDirExists) {
-      ctx.logger.debug('Creating profile %O in %s', profileDir);
+      ctx.logger.debug('Creating profile in %s', profileDir);
       fs.mkdirSync(profileDir, { recursive: true });
     }
 

--- a/platforms/guardoni/src/guardoni/profile.ts
+++ b/platforms/guardoni/src/guardoni/profile.ts
@@ -32,13 +32,9 @@ export const getDefaultProfile = (
   };
 };
 
-// todo: check if a profile already exists in the file system
-export const checkProfile =
+export const getExistingProfiles =
   (ctx: { logger: GuardoniContext['logger'] }) =>
-  (
-    basePath: string,
-    conf: GuardoniConfig
-  ): TE.TaskEither<AppError, GuardoniProfile> => {
+  (basePath: string): string[] => {
     const profilesDir = path.resolve(basePath, 'profiles');
 
     ctx.logger.debug('Check profile at %s', profilesDir);
@@ -52,8 +48,17 @@ export const checkProfile =
       fs.mkdirSync(profilesDir, { recursive: true });
     }
 
-    const profiles = fs.readdirSync(profilesDir);
+    return fs.readdirSync(profilesDir);
+  };
 
+// todo: check if a profile already exists in the file system
+export const checkProfile =
+  (ctx: { logger: GuardoniContext['logger'] }) =>
+  (
+    basePath: string,
+    conf: GuardoniConfig
+  ): TE.TaskEither<AppError, GuardoniProfile> => {
+    const profiles = getExistingProfiles(ctx)(basePath);
     // no profile given, try to retrieve the old one
 
     ctx.logger.debug('Profiles %O', profiles);

--- a/platforms/guardoni/src/guardoni/types.ts
+++ b/platforms/guardoni/src/guardoni/types.ts
@@ -1,4 +1,4 @@
-import * as endpoints  from '@shared/endpoints';
+import * as endpoints from '@shared/endpoints';
 import { Logger } from '@shared/logger';
 import { DirectiveType } from '@shared/models/Directive';
 import { APIClient } from '@shared/providers/api.provider';
@@ -15,6 +15,7 @@ export const PlatformConfig = t.strict(
   {
     name: Platform,
     backend: t.string,
+    frontend: t.union([t.string, t.undefined]),
     extensionDir: t.string,
     proxy: t.union([t.string, t.undefined]),
   },
@@ -41,18 +42,6 @@ export const GuardoniConfig = t.strict(
 );
 
 export type GuardoniConfig = t.TypeOf<typeof GuardoniConfig>;
-
-export const GuardoniPlatformConfig = t.strict(
-  {
-    name: t.union([t.literal('tiktok'), t.literal('youtube')]),
-    backend: t.string,
-    extensionDir: t.string,
-    proxy: t.union([t.string, t.undefined]),
-  },
-  'GuardoniPlatformConfig'
-);
-
-export type GuardoniPlatformConfig = t.TypeOf<typeof GuardoniPlatformConfig>;
 
 export interface ProgressDetails {
   message: string;

--- a/platforms/yttrex/extension/webpack.config.ts
+++ b/platforms/yttrex/extension/webpack.config.ts
@@ -60,7 +60,7 @@ const { buildENV, ...extensionConfig } = getExtensionConfig(
       } else if (extensionConfig.mode === 'development') {
         manifest.permissions = manifest.permissions
           .filter((p: string) => !p.includes('youtube.tracking.exposed'))
-          .concat(['http://localhost:9000']);
+          .concat(['http://localhost:9000/']);
       }
 
       if (buildENV.BUNDLE_TARGET === 'chrome') {


### PR DESCRIPTION
The UI profile selection now works and the profile is correctly retrieved on the following runs.
I also added a link for the experiment id in the execution page as @vecna asked, but I'll wait to check this with @spaghettinucleari before merging