### PR TITLE
fix(ycai): channel related id patch

### DIFF
--- a/packages/shared/src/models/ChannelRelated.ts
+++ b/packages/shared/src/models/ChannelRelated.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 
 export const ChannelRelated = t.strict(
   {
-    id: t.string,
+    id: t.union([t.string, t.undefined]),
     recommendedSource: t.union([t.string, t.null]),
     recommendedChannelCount: t.number,
     percentage: t.number,

--- a/packages/taboule/src/config/index.tsx
+++ b/packages/taboule/src/config/index.tsx
@@ -57,6 +57,7 @@ export const defaultConfiguration = (
 ): TabouleConfiguration => {
   return {
     ccRelatedUsers: {
+      getRowId: (d) => d.id ?? d.recommendedSource ?? d.percentage,
       inputs: inputs.channelIdInput,
       columns: [
         {


### PR DESCRIPTION
This is meant to be a temporary fix till we wait for the deploy of yttrex API v2.5