### PR TITLE
chore: pm2 all platforms

### DIFF
--- a/platforms/ecosystem.config.js
+++ b/platforms/ecosystem.config.js
@@ -1,0 +1,11 @@
+const yt = require('./yttrex/backend/ecosystem.config');
+const tk = require('./tktrex/backend/ecosystem.config');
+
+module.exports = {
+  apps: [
+    // yt.ecosystem
+    ...yt.apps,
+    // tk ecosystem
+    ...tk.apps,
+  ],
+};


### PR DESCRIPTION
I've defined a single entrypoint to launch all the platforms services in one command: `yarn pm2 platforms/ecosystem.config.js`