### PR TITLE
chore: use publicKey and secretKey from process.env in extension

### DIFF
--- a/packages/shared/src/extension/chrome/background/account.ts
+++ b/packages/shared/src/extension/chrome/background/account.ts
@@ -18,7 +18,17 @@ const FIXED_USER_NAME = 'local';
 // defaults of the settings stored in 'config' and controlled by popup
 const DEFAULT_SETTINGS = { active: true, ux: false, researchTag: '' };
 
+/**
+ * Create publicKey and secretKey
+ */
 export function initializeKey(): KeyPair {
+  // use publicKey and secretKey from process.env when available
+  if (process.env.PUBLIC_KEY && process.env.SECRET_KEY) {
+    return {
+      publicKey: process.env.PUBLIC_KEY,
+      secretKey: process.env.SECRET_KEY,
+    };
+  }
   const newKeypair = nacl.sign.keyPair();
   const publicKey = bs58.encode(newKeypair.publicKey);
   log.info('initializing new key pair:', publicKey);

--- a/platforms/tktrex/extension/src/AppEnv.ts
+++ b/platforms/tktrex/extension/src/AppEnv.ts
@@ -10,6 +10,8 @@ export const AppEnv = t.strict(
     BUILD_DATE: t.string,
     FLUSH_INTERVAL: t.string,
     DEBUG: t.string,
+    PUBLIC_KEY: t.union([t.string, t.undefined]),
+    SECRET_KEY: t.union([t.string, t.undefined]),
   },
   'TkTrexAppEnv',
 );

--- a/platforms/yttrex/extension/webpack.config.ts
+++ b/platforms/yttrex/extension/webpack.config.ts
@@ -46,6 +46,8 @@ const { buildENV, ...extensionConfig } = getExtensionConfig(
         BUILD_DATE: t.string,
         FLUSH_INTERVAL: NumberFromString,
         DATA_CONTRIBUTION_ENABLED: BooleanFromString,
+        PUBLIC_KEY: t.union([t.string, t.undefined]),
+        SECRET_KEY: t.union([t.string, t.undefined]),
       },
       'YTTrExAppEnv'
     ),


### PR DESCRIPTION
With this PR is possible to build an extension with specific `publicKey` and `secreteKey` with:
```sh
# yttrex ext build
PUBLIC_KEY=XXX SECRET_KEY=XXX yarn yt:ext build

# tktrex ext build
PUBLIC_KEY=XXX SECRET_KEY=XXX yarn tk:ext build
```