### PR TITLE
fix(guardoni): extension url template aligned with extension zip file names

### DIFF
--- a/platforms/guardoni/src/guardoni/extension.ts
+++ b/platforms/guardoni/src/guardoni/extension.ts
@@ -18,7 +18,7 @@ import { GuardoniContext, Platform } from './types';
 
 const getExtensionWithOptInURL = (platform: Platform, v: string): string => {
   const platformChunk = platform === 'youtube' ? 'yttrex' : 'tktrex';
-  return `https://github.com/tracking-exposed/yttrex/releases/download/v${v}/guardoni-${platformChunk}-extension-${v}.zip`;
+  return `https://github.com/tracking-exposed/yttrex/releases/download/v${v}/${platformChunk}-guardoni-extension-${v}.zip`;
 };
 
 export const downloadExtension = (


### PR DESCRIPTION
This will prevent my manual edit of the release assets names to make them downloadable by guardoni.