### PR TITLE
fix(tktrex): get public directive

### DIFF
--- a/platforms/tktrex/backend/routes/directives.js
+++ b/platforms/tktrex/backend/routes/directives.js
@@ -109,6 +109,8 @@ async function getPublic(req) {
 
   return {
     json: publicDirectives,
+    total: publicDirectives.length,
+    content: publicDirectives,
   };
 }
 


### PR DESCRIPTION
This fix the compatibility with guardoni experiments listing